### PR TITLE
Extend cloud-config format

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
 language: go
 go_import_path: kubevirt.io/cloud-provider-kubevirt
 go:
-- 1.11.x
+- 1.12.x

--- a/pkg/cloudprovider/kubevirt/cloud.go
+++ b/pkg/cloudprovider/kubevirt/cloud.go
@@ -3,6 +3,7 @@ package kubevirt
 import (
 	"bytes"
 	"fmt"
+	"gopkg.in/yaml.v2"
 	"io"
 
 	"github.com/golang/glog"
@@ -20,6 +21,54 @@ const (
 type cloud struct {
 	namespace string
 	kubevirt  kubecli.KubevirtClient
+	config    CloudConfig
+}
+
+type CloudConfig struct {
+	Kubeconfig   string             `yaml:"kubeconfig"` // The kubeconfig used to connect to the underkube
+	LoadBalancer LoadBalancerConfig `yaml:"loadbalancer"`
+	Instances    InstancesConfig    `yaml:"instances"`
+	Zones        ZonesConfig        `yaml:"zones"`
+}
+
+type LoadBalancerConfig struct {
+	Enabled              bool `yaml:"enabled"`              // Enables the loadbalancer interface of the CCM
+	CreationPollInterval int  `yaml:"creationPollInterval"` // How many seconds to wait for the loadbalancer creation
+}
+
+type InstancesConfig struct {
+	Enabled             bool `yaml:"enabled"`             // Enables the instances interface of the CCM
+	EnableInstanceTypes bool `yaml:"enableInstanceTypes"` // Enables 'flavor' annotation to detect instance types
+}
+
+type ZonesConfig struct {
+	Enabled bool `yaml:"enabled"` // Enables the zones interface of the CCM
+}
+
+// createDefaultCloudConfig creates a CloudConfig object filled with default values.
+// These default values should be overwritten by values read from the cloud-config file.
+func createDefaultCloudConfig() CloudConfig {
+	return CloudConfig{
+		LoadBalancer: LoadBalancerConfig{
+			Enabled:              true,
+			CreationPollInterval: defaultLoadBalancerCreatePollInterval,
+		},
+		Instances: InstancesConfig{
+			Enabled: true,
+		},
+		Zones: ZonesConfig{
+			Enabled: true,
+		},
+	}
+}
+
+func NewCloudConfigFromBytes(configBytes []byte) (CloudConfig, error) {
+	var config = createDefaultCloudConfig()
+	err := yaml.Unmarshal(configBytes, &config)
+	if err != nil {
+		return CloudConfig{}, err
+	}
+	return config, nil
 }
 
 func init() {
@@ -32,8 +81,15 @@ func kubevirtCloudProviderFactory(config io.Reader) (cloudprovider.Interface, er
 	}
 
 	buf := new(bytes.Buffer)
-	buf.ReadFrom(config)
-	clientConfig, err := clientcmd.NewClientConfigFromBytes(buf.Bytes())
+	_, err := buf.ReadFrom(config)
+	if err != nil {
+		return nil, fmt.Errorf("Failed to read cloud provider config: %v", err)
+	}
+	cloudConf, err := NewCloudConfigFromBytes(buf.Bytes())
+	if err != nil {
+		return nil, fmt.Errorf("Failed to unmarshal cloud provider config: %v", err)
+	}
+	clientConfig, err := clientcmd.NewClientConfigFromBytes([]byte(cloudConf.Kubeconfig))
 	if err != nil {
 		return nil, err
 	}
@@ -50,6 +106,7 @@ func kubevirtCloudProviderFactory(config io.Reader) (cloudprovider.Interface, er
 	return &cloud{
 		namespace: namespace,
 		kubevirt:  kubevirtClient,
+		config:    cloudConf,
 	}, nil
 }
 
@@ -59,22 +116,33 @@ func (c *cloud) Initialize(clientBuilder controller.ControllerClientBuilder) {}
 
 // LoadBalancer returns a balancer interface. Also returns true if the interface is supported, false otherwise.
 func (c *cloud) LoadBalancer() (cloudprovider.LoadBalancer, bool) {
+	if !c.config.LoadBalancer.Enabled {
+		return nil, false
+	}
 	return &loadbalancer{
 		namespace: c.namespace,
 		kubevirt:  c.kubevirt,
+		config:    c.config.LoadBalancer,
 	}, true
 }
 
 // Instances returns an instances interface. Also returns true if the interface is supported, false otherwise.
 func (c *cloud) Instances() (cloudprovider.Instances, bool) {
+	if !c.config.Instances.Enabled {
+		return nil, false
+	}
 	return &instances{
 		namespace: c.namespace,
 		kubevirt:  c.kubevirt,
+		config:    c.config.Instances,
 	}, true
 }
 
 // Zones returns a zones interface. Also returns true if the interface is supported, false otherwise.
 func (c *cloud) Zones() (cloudprovider.Zones, bool) {
+	if !c.config.Zones.Enabled {
+		return nil, false
+	}
 	return &zones{
 		namespace: c.namespace,
 		kubevirt:  c.kubevirt,

--- a/pkg/cloudprovider/kubevirt/cloud_test.go
+++ b/pkg/cloudprovider/kubevirt/cloud_test.go
@@ -1,15 +1,99 @@
 package kubevirt
 
 import (
+	"fmt"
+	"reflect"
+	"strings"
 	"testing"
 )
+
+const kubeconfig = `apiVersion: v1
+clusters:
+- cluster:
+    certificate-authority-data: cert-auth-data
+    server: https://127.0.0.1:6443
+  name: kubernetes
+contexts:
+- context:
+    cluster: kubernetes
+    user: kubernetes-admin
+    namespace: default
+  name: kubernetes-admin@kubernetes
+current-context: kubernetes-admin@kubernetes
+kind: Config
+preferences: {}
+users:
+- name: kubernetes-admin
+  user:
+    client-certificate-data: cert-data
+    client-key-data: key-data
+`
+
+var (
+	minimalConf      = fmt.Sprintf("kubeconfig: |\n%s", indent(kubeconfig, "  "))
+	loadbalancerConf = fmt.Sprintf("kubeconfig: |\n%s\nloadbalancer:\n  enabled: %t\n  creationPollInterval: %d", indent(kubeconfig, "  "), false, 3)
+	instancesConf    = fmt.Sprintf("kubeconfig: |\n%s\ninstances:\n  enabled: %t\n  enableInstanceTypes: %t", indent(kubeconfig, "  "), false, true)
+	zonesConf        = fmt.Sprintf("kubeconfig: |\n%s\nzones:\n  enabled: %t", indent(kubeconfig, "  "), false)
+	allConf          = fmt.Sprintf("kubeconfig: |\n%s\nloadbalancer:\n  enabled: %t\ninstances:\n  enabled: %t\nzones:\n  enabled: %t", indent(kubeconfig, "  "), false, false, false)
+	invalidKubeconf  = "kubeconfig: bla"
+)
+
+func indent(s, indent string) string {
+	return indent + strings.ReplaceAll(s, "\n", fmt.Sprintf("\n%s", indent))
+}
+
+func makeCloudConfig(kubeconfig string, loadbalancerEnabled, instancesEnabled, zonesEnabled bool, lbCreationPollInterval int, enableInstanceTypes bool) CloudConfig {
+	return CloudConfig{
+		Kubeconfig: kubeconfig,
+		LoadBalancer: LoadBalancerConfig{
+			Enabled:              loadbalancerEnabled,
+			CreationPollInterval: lbCreationPollInterval,
+		},
+		Instances: InstancesConfig{
+			Enabled:             instancesEnabled,
+			EnableInstanceTypes: enableInstanceTypes,
+		},
+		Zones: ZonesConfig{
+			Enabled: zonesEnabled,
+		},
+	}
+}
+
+func TestNewCloudConfigFromBytes(t *testing.T) {
+	tests := []struct {
+		configBytes         string
+		expectedCloudConfig CloudConfig
+		expectedError       error
+	}{
+		{minimalConf, makeCloudConfig(kubeconfig, true, true, true, 5, false), nil},
+		{loadbalancerConf, makeCloudConfig(kubeconfig, false, true, true, 3, false), nil},
+		{instancesConf, makeCloudConfig(kubeconfig, true, false, true, 5, true), nil},
+		{zonesConf, makeCloudConfig(kubeconfig, true, true, false, 5, false), nil},
+		{allConf, makeCloudConfig(kubeconfig, false, false, false, 5, false), nil},
+	}
+
+	for _, test := range tests {
+		config, err := NewCloudConfigFromBytes([]byte(test.configBytes))
+		if !reflect.DeepEqual(config, test.expectedCloudConfig) {
+			t.Errorf("Expected: %v, got %v", test.expectedCloudConfig, config)
+		}
+		if test.expectedError != nil && err != nil && err.Error() != test.expectedError.Error() {
+			t.Errorf("Expected: '%v', got '%v'", test.expectedError, err)
+		}
+	}
+}
 
 func TestKubevirtCloudProviderFactory(t *testing.T) {
 	// Calling kubevirtCloudProviderFactory without config should return an error
 	_, err := kubevirtCloudProviderFactory(nil)
-	if err.Error() != "No kubevirt cloud provider config file given" {
-		t.Error("Kubevirt cloudprovider Factory should return an error if invoked with nil.")
+	if err == nil {
+		t.Error("Expected: 'No kubevirt cloud provider config file given', got 'nil'")
+	} else if err.Error() != "No kubevirt cloud provider config file given" {
+		t.Errorf("Expected: 'No kubevirt cloud provider config file given', got '%v'", err)
 	}
 
-	// TODO: Test factory with defined cloud-configs
+	_, err = kubevirtCloudProviderFactory(strings.NewReader(invalidKubeconf))
+	if err == nil || !strings.Contains(err.Error(), "couldn't get version/kind; json parse error") {
+		t.Errorf("Expected error containing: 'couldn't get version/kind; json parse error', got '%v'", err)
+	}
 }

--- a/pkg/cloudprovider/kubevirt/instances.go
+++ b/pkg/cloudprovider/kubevirt/instances.go
@@ -25,6 +25,7 @@ const (
 type instances struct {
 	namespace string
 	kubevirt  kubecli.KubevirtClient
+	config    InstancesConfig
 }
 
 // Must match providerIDs built by cloudprovider.GetInstanceProviderID
@@ -140,6 +141,10 @@ func (i *instances) InstanceTypeByProviderID(ctx context.Context, providerID str
 }
 
 func (i *instances) instanceTypeByInstanceID(ctx context.Context, instanceID string) (string, error) {
+	if !i.config.EnableInstanceTypes {
+		// Only try to detect instance type if enabled
+		return "", nil
+	}
 	vmi, err := i.kubevirt.VirtualMachineInstance(i.namespace).Get(instanceID, &metav1.GetOptions{})
 	if err != nil {
 		glog.Errorf("Failed to get instance with instance ID %s in namespace %s: %v", instanceID, i.namespace, err)

--- a/pkg/cloudprovider/kubevirt/instances_test.go
+++ b/pkg/cloudprovider/kubevirt/instances_test.go
@@ -94,6 +94,9 @@ func mockInstances(t *testing.T, namespace string) cloudprovider.Instances {
 	return &instances{
 		namespace: namespace,
 		kubevirt:  kubevirt,
+		config: InstancesConfig{
+			EnableInstanceTypes: true,
+		},
 	}
 }
 


### PR DESCRIPTION
ATM KubeVirt-cloud-controller-manager accepts a kubeconfig file as cloud-config.
This patch extends the format of cloud-config to support additional configuration beyond kubeconfig.

For example, this cloud-config sets the kubeconfig and disables the loadbalancer interface.
```
kubeconfig: |
  apiVersion: v1
  clusters:
  - cluster:
      certificate-authority-data: xxx
      server: https://127.0.0.1:6443
    name: kubernetes
  contexts:
  - context:
      cluster: kubernetes
      user: kubernetes-admin
      namespace: shoots
    name: kubernetes-admin@kubernetes
  current-context: kubernetes-admin@kubernetes
  kind: Config
  preferences: {}
  users:
  - name: kubernetes-admin
    user:
      client-certificate-data: xxx
      client-key-data: xxx
loadbalancer:
  enbled: false
```