### PR TITLE
Consider newer topology labels in zone controller

### DIFF
--- a/pkg/cloudprovider/kubevirt/zones.go
+++ b/pkg/cloudprovider/kubevirt/zones.go
@@ -60,10 +60,16 @@ func (z *zones) getZoneByInstanceID(ctx context.Context, instanceID string) (clo
 
 	// Take over failure domain and region from node where the instance is running on.
 	zone := cloudprovider.Zone{}
-	if failureDomain, ok := node.ObjectMeta.Labels[corev1.LabelZoneFailureDomain]; ok {
+	// TODO Use corev1.LabelZoneFailureDomainStable when the k8s.io/api/core/v1 dependency is updated to 1.17 or greater
+	if failureDomain, ok := node.ObjectMeta.Labels["topology.kubernetes.io/zone"]; ok {
+		zone.FailureDomain = failureDomain
+	} else if failureDomain, ok := node.ObjectMeta.Labels[corev1.LabelZoneFailureDomain]; ok {
 		zone.FailureDomain = failureDomain
 	}
-	if region, ok := node.ObjectMeta.Labels[corev1.LabelZoneRegion]; ok {
+	// TODO Use corev1.LabelZoneRegionStable when the k8s.io/api/core/v1 dependency is updated to 1.17 or greater
+	if region, ok := node.ObjectMeta.Labels["topology.kubernetes.io/region"]; ok {
+		zone.Region = region
+	} else if region, ok := node.ObjectMeta.Labels[corev1.LabelZoneRegion]; ok {
 		zone.Region = region
 	}
 


### PR DESCRIPTION
This PR adds code to consider the newer `topology` labels in the zone controller, in addition to the older `failure-domain` ones. According to https://kubernetes.io/docs/reference/kubernetes-api/labels-annotations-taints/, starting in v1.17, the  `failure-domain.beta.kubernetes.io/region` label is deprecated in favor of `topology.kubernetes.io/region`, and the `failure-domain.beta.kubernetes.io/zone` label is deprecated in favor of `topology.kubernetes.io/zone`.

Since the cloud provider still vendors Kubernetes 1.16, the newer labels of the underkube nodes will be considered when determining the region and zone, but not actually added to the overkube nodes (as this is done by the vendored code). Vendoring a newer Kubernetes version is unfortunately close to impossible since [kubevirt.io/client-go](https://github.com/kubevirt/kubevirt/tree/master/staging/src/kubevirt.io/client-go) is still based on 1.16 and there are conflicts, see also #10.
