### PR TITLE
Copy annotations from proxied service to proxy

### DIFF
--- a/pkg/cloudprovider/kubevirt/loadbalancer.go
+++ b/pkg/cloudprovider/kubevirt/loadbalancer.go
@@ -189,11 +189,13 @@ func (lb *loadbalancer) createLoadBalancerService(ctx context.Context, lbName st
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      lbName,
 			Namespace: lb.namespace,
+			Annotations: service.Annotations,
 		},
 		Spec: corev1.ServiceSpec{
 			Ports:    ports,
 			Selector: map[string]string{serviceLabelKey(lbName): service.ObjectMeta.Name},
 			Type:     corev1.ServiceTypeLoadBalancer,
+			ExternalTrafficPolicy: service.Spec.ExternalTrafficPolicy,
 		},
 	}
 	if len(service.Spec.ExternalIPs) > 0 {


### PR DESCRIPTION
This PR copies annotations that are on a proxied `Service` to the proxy and is required in the Gardener Kubevirt provider so that a MetalLB instance in the seed can be configured by the shoot (such as address pool selection).

/resolves #15 

cc: @stoyanr 