### PR TITLE
Replace Travis CI with GitHub Actions

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,0 +1,24 @@
+name: Go
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Set up Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.15
+
+      - name: Build
+        run: go build -v ./...
+
+      - name: Test
+        run: go test -v ./...

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,0 @@
-language: go
-dist: xenial
-go_import_path: kubevirt.io/cloud-provider-kubevirt
-go:
-- 1.15.x


### PR DESCRIPTION
It seems like Travis CI does no longer trigger any tests on new PRs or pushes.

This PR replaces the Travis CI configuration with GitHub Actions in hope that
it will work more reliable.
