### PR TITLE
Add functionality to get instance id from node name by regexp

### DIFF
--- a/pkg/cloudprovider/kubevirt/cloud.go
+++ b/pkg/cloudprovider/kubevirt/cloud.go
@@ -28,7 +28,7 @@ type cloud struct {
 }
 
 type CloudConfig struct {
-	Kubeconfig   string             `yaml:"kubeconfig"` // The kubeconfig used to connect to the underkube
+	Kubeconfig   string             `yaml:"kubeconfig"` // The kubeconfig used to connect to the infra cluster
 	LoadBalancer LoadBalancerConfig `yaml:"loadbalancer"`
 	Instances    InstancesConfig    `yaml:"instances"`
 	Zones        ZonesConfig        `yaml:"zones"`
@@ -40,8 +40,9 @@ type LoadBalancerConfig struct {
 }
 
 type InstancesConfig struct {
-	Enabled             bool `yaml:"enabled"`             // Enables the instances interface of the CCM
-	EnableInstanceTypes bool `yaml:"enableInstanceTypes"` // Enables 'flavor' annotation to detect instance types
+	Enabled               bool   `yaml:"enabled"`               // Enables the instances interface of the CCM
+	EnableInstanceTypes   bool   `yaml:"enableInstanceTypes"`   // Enables 'flavor' annotation to detect instance types
+	MatchInstanceIDRegexp string `yaml:"matchInstanceIDRegexp"` // Regexp to match instance id from node name
 }
 
 type ZonesConfig struct {
@@ -125,7 +126,7 @@ func (c *cloud) LoadBalancer() (cloudprovider.LoadBalancer, bool) {
 	return &loadbalancer{
 		namespace: c.namespace,
 		client:    c.client,
-		config:    c.config.LoadBalancer,
+		config:    c.config,
 	}, true
 }
 
@@ -137,7 +138,7 @@ func (c *cloud) Instances() (cloudprovider.Instances, bool) {
 	return &instances{
 		namespace: c.namespace,
 		client:    c.client,
-		config:    c.config.Instances,
+		config:    c.config,
 	}, true
 }
 
@@ -153,6 +154,7 @@ func (c *cloud) Zones() (cloudprovider.Zones, bool) {
 	return &zones{
 		namespace: c.namespace,
 		client:    c.client,
+		config:    c.config,
 	}, true
 }
 

--- a/pkg/cloudprovider/kubevirt/loadbalancer.go
+++ b/pkg/cloudprovider/kubevirt/loadbalancer.go
@@ -30,7 +30,7 @@ const (
 type loadbalancer struct {
 	namespace string
 	client    client.Client
-	config    LoadBalancerConfig
+	config    CloudConfig
 }
 
 // GetLoadBalancer returns whether the specified load balancer exists, and
@@ -314,10 +314,10 @@ func (lb *loadbalancer) ensureServiceLabelsDeleted(ctx context.Context, lbName, 
 }
 
 func (lb *loadbalancer) getLoadBalancerCreatePollInterval() time.Duration {
-	if lb.config.CreationPollInterval > 0 {
-		return time.Duration(lb.config.CreationPollInterval)
+	if lb.config.LoadBalancer.CreationPollInterval > 0 {
+		return time.Duration(lb.config.LoadBalancer.CreationPollInterval)
 	}
-	klog.Infof("Creation poll interval '%d' must be > 0. Setting to '%d'", lb.config.CreationPollInterval, defaultLoadBalancerCreatePollInterval)
+	klog.Infof("Creation poll interval '%d' must be > 0. Setting to '%d'", lb.config.LoadBalancer.CreationPollInterval, defaultLoadBalancerCreatePollInterval)
 	return defaultLoadBalancerCreatePollInterval
 }
 

--- a/pkg/cloudprovider/kubevirt/loadbalancer_test.go
+++ b/pkg/cloudprovider/kubevirt/loadbalancer_test.go
@@ -319,8 +319,10 @@ func TestEnsureLoadBalancer(t *testing.T) {
 	lb := &loadbalancer{
 		namespace: "test",
 		client:    c,
-		config: LoadBalancerConfig{
-			CreationPollInterval: 1,
+		config: CloudConfig{
+			LoadBalancer: LoadBalancerConfig{
+				CreationPollInterval: 1,
+			},
 		},
 	}
 

--- a/pkg/cloudprovider/kubevirt/zones.go
+++ b/pkg/cloudprovider/kubevirt/zones.go
@@ -14,6 +14,7 @@ import (
 type zones struct {
 	namespace string
 	client    client.Client
+	config    CloudConfig
 }
 
 // GetZone returns the Zone containing the current failure zone and locality region that the program is running in
@@ -40,7 +41,10 @@ func (z *zones) GetZoneByProviderID(ctx context.Context, providerID string) (clo
 // This method is particularly used in the context of external cloud providers where node initialization must be down
 // outside the kubelets.
 func (z *zones) GetZoneByNodeName(ctx context.Context, nodeName types.NodeName) (cloudprovider.Zone, error) {
-	instanceID := instanceIDFromNodeName(string(nodeName))
+	instanceID, err := instanceIDFromNodeName(string(nodeName), z.config.Instances.MatchInstanceIDRegexp)
+	if err != nil {
+		return cloudprovider.Zone{}, err
+	}
 	return z.getZoneByInstanceID(ctx, instanceID)
 }
 


### PR DESCRIPTION
This PR allows to fetch instance id (VM name) from node name by regexp.
It eliminates the hardcoded assumption https://github.com/kubevirt/cloud-provider-kubevirt/compare/main...mfranczy:instance-regexp?expand=1#diff-f1870dea0d991df0bf3f60c36b21ec968cfbc5a0e77a6e55e17c587dfaf16811L236