### PR TITLE
Add a possibility to read namespace from CCM config

### DIFF
--- a/pkg/provider/cloud.go
+++ b/pkg/provider/cloud.go
@@ -38,6 +38,7 @@ type CloudConfig struct {
 	Kubeconfig   string             `yaml:"kubeconfig"`
 	LoadBalancer LoadBalancerConfig `yaml:"loadBalancer"`
 	InstancesV2  InstancesV2Config  `yaml:"instancesV2"`
+	Namespace    string             `yaml:"namespace"`
 }
 
 type LoadBalancerConfig struct {
@@ -97,10 +98,13 @@ func kubevirtCloudProviderFactory(config io.Reader) (cloudprovider.Interface, er
 	if err != nil {
 		return nil, err
 	}
-	namespace, _, err := clientConfig.Namespace()
-	if err != nil {
-		klog.Errorf("Could not find namespace in client config: %v", err)
-		return nil, err
+	namespace := cloudConf.Namespace
+	if namespace == "" {
+		namespace, _, err = clientConfig.Namespace()
+		if err != nil {
+			klog.Errorf("Could not find namespace in client config: %v", err)
+			return nil, err
+		}
 	}
 	c, err := client.New(restConfig, client.Options{
 		Scheme: scheme,

--- a/pkg/provider/cloud_test.go
+++ b/pkg/provider/cloud_test.go
@@ -30,11 +30,13 @@ users:
 `
 
 var (
+	ns               = "aNamespace"
 	minimalConf      = fmt.Sprintf("kubeconfig: |\n%s", indent(kubeconfig, "  "))
 	loadbalancerConf = fmt.Sprintf("kubeconfig: |\n%s\nloadBalancer:\n  enabled: %t\n  creationPollInterval: %d", indent(kubeconfig, "  "), false, 3)
 	instancesConf    = fmt.Sprintf("kubeconfig: |\n%s\ninstancesV2:\n  enabled: %t\n  enableInstanceTypes: %t", indent(kubeconfig, "  "), false, true)
 	zonesConf        = fmt.Sprintf("kubeconfig: |\n%s\nzones:\n  enabled: %t", indent(kubeconfig, "  "), false)
-	allConf          = fmt.Sprintf("kubeconfig: |\n%s\nloadBalancer:\n  enabled: %t\ninstancesV2:\n  enabled: %t", indent(kubeconfig, "  "), false, false)
+	namespaceConf    = fmt.Sprintf("kubeconfig: |\n%s\nnamespace: %s", indent(kubeconfig, "  "), ns)
+	allConf          = fmt.Sprintf("kubeconfig: |\n%s\nloadBalancer:\n  enabled: %t\ninstancesV2:\n  enabled: %t\nnamespace: %s", indent(kubeconfig, "  "), false, false, ns)
 	invalidKubeconf  = "kubeconfig: bla"
 )
 
@@ -42,7 +44,7 @@ func indent(s, indent string) string {
 	return indent + strings.ReplaceAll(s, "\n", fmt.Sprintf("\n%s", indent))
 }
 
-func makeCloudConfig(kubeconfig string, loadbalancerEnabled, instancesEnabled bool, lbCreationPollInterval int) CloudConfig {
+func makeCloudConfig(kubeconfig, namespace string, loadbalancerEnabled, instancesEnabled bool, lbCreationPollInterval int) CloudConfig {
 	return CloudConfig{
 		Kubeconfig: kubeconfig,
 		LoadBalancer: LoadBalancerConfig{
@@ -52,6 +54,7 @@ func makeCloudConfig(kubeconfig string, loadbalancerEnabled, instancesEnabled bo
 		InstancesV2: InstancesV2Config{
 			Enabled: instancesEnabled,
 		},
+		Namespace: namespace,
 	}
 }
 
@@ -61,10 +64,11 @@ func TestNewCloudConfigFromBytes(t *testing.T) {
 		expectedCloudConfig CloudConfig
 		expectedError       error
 	}{
-		{minimalConf, makeCloudConfig(kubeconfig, true, true, 5), nil},
-		{loadbalancerConf, makeCloudConfig(kubeconfig, false, true, 3), nil},
-		{instancesConf, makeCloudConfig(kubeconfig, true, false, 5), nil},
-		{allConf, makeCloudConfig(kubeconfig, false, false, 5), nil},
+		{minimalConf, makeCloudConfig(kubeconfig, "", true, true, 5), nil},
+		{loadbalancerConf, makeCloudConfig(kubeconfig, "", false, true, 3), nil},
+		{instancesConf, makeCloudConfig(kubeconfig, "", true, false, 5), nil},
+		{namespaceConf, makeCloudConfig(kubeconfig, ns, true, true, 5), nil},
+		{allConf, makeCloudConfig(kubeconfig, ns, false, false, 5), nil},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
This PR allows to read the cloud namespace from CCM config instead of always reading it from the kubeconfig.
Fixes: #78 
Signed-off-by: Helene Durand <helene@kubermatic.com>