### PR TITLE
infra: Add a gh actions to publish images

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,0 +1,30 @@
+name: publish
+
+on:
+  push:
+    branches:
+    - main
+    tags:
+    - 'v*.*.*'
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    env:
+      VERSION: ${{github.ref_name}}
+      REGISTRY: quay.io/kubevirt
+    steps:
+      - uses: actions/checkout@v2
+      - uses: arnested/go-version-action@v1
+        id: go-versions
+      - name: Setup Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: ${{ steps.go-versions.outputs.minimal }}
+      - name: Logging to quay.io
+        run: 
+          docker login -u ${{ secrets.QUAY_USER }} -p ${{ secrets.QUAY_TOKEN }} quay.io
+      - name: Build and push image
+        run: make build push


### PR DESCRIPTION
After a PR is merged or main branch tagged a image should be pushed to
quay.io. This change add a github actions that do so and also add a
manual trigger to actionate from github actions menu or github CLI.