### PR TITLE
make: Disable CGO

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ test:
 
 .PHONY: build
 build: bin
-	GOOS=linux go build -ldflags="-s -w" -o bin/kubevirt-cloud-controller-manager ./cmd/kubevirt-cloud-controller-manager
+	CGO_ENABLED=0 GOOS=linux go build -ldflags="-s -w" -o bin/kubevirt-cloud-controller-manager ./cmd/kubevirt-cloud-controller-manager
 
 .PHONY:image
 image: build


### PR DESCRIPTION
The alpine image does not containe the needed librarys to run non
statically linked golang binary. This change disable CGO to compile into
a statically linked one.