### PR TITLE
InstancesV2: Add option to disable getting  Region and Zone labels

### DIFF
--- a/pkg/provider/cloud.go
+++ b/pkg/provider/cloud.go
@@ -51,6 +51,8 @@ type LoadBalancerConfig struct {
 type InstancesV2Config struct {
 	// Enabled activates the instances interface of the CCM
 	Enabled bool `yaml:"enabled"`
+	// ZoneAndRegionEnabled indicates if need to get Region and zone labels from the cloud provider
+	ZoneAndRegionEnabled bool `yaml:"zoneAndRegionEnabled"`
 }
 
 // createDefaultCloudConfig creates a CloudConfig object filled with default values.
@@ -62,7 +64,8 @@ func createDefaultCloudConfig() CloudConfig {
 			CreationPollInterval: defaultLoadBalancerCreatePollInterval,
 		},
 		InstancesV2: InstancesV2Config{
-			Enabled: true,
+			Enabled:              true,
+			ZoneAndRegionEnabled: true,
 		},
 	}
 }
@@ -148,7 +151,7 @@ func (c *cloud) InstancesV2() (cloudprovider.InstancesV2, bool) {
 	return &instancesV2{
 		namespace: c.namespace,
 		client:    c.client,
-		config:    c.config.InstancesV2,
+		config:    &c.config.InstancesV2,
 	}, true
 }
 

--- a/pkg/provider/cloud_test.go
+++ b/pkg/provider/cloud_test.go
@@ -30,21 +30,21 @@ users:
 `
 
 var (
-	ns               = "aNamespace"
-	minimalConf      = fmt.Sprintf("kubeconfig: |\n%s", indent(kubeconfig, "  "))
-	loadbalancerConf = fmt.Sprintf("kubeconfig: |\n%s\nloadBalancer:\n  enabled: %t\n  creationPollInterval: %d", indent(kubeconfig, "  "), false, 3)
-	instancesConf    = fmt.Sprintf("kubeconfig: |\n%s\ninstancesV2:\n  enabled: %t\n  enableInstanceTypes: %t", indent(kubeconfig, "  "), false, true)
-	zonesConf        = fmt.Sprintf("kubeconfig: |\n%s\nzones:\n  enabled: %t", indent(kubeconfig, "  "), false)
-	namespaceConf    = fmt.Sprintf("kubeconfig: |\n%s\nnamespace: %s", indent(kubeconfig, "  "), ns)
-	allConf          = fmt.Sprintf("kubeconfig: |\n%s\nloadBalancer:\n  enabled: %t\ninstancesV2:\n  enabled: %t\nnamespace: %s", indent(kubeconfig, "  "), false, false, ns)
-	invalidKubeconf  = "kubeconfig: bla"
+	ns                = "aNamespace"
+	minimalConf       = fmt.Sprintf("kubeconfig: |\n%s", indent(kubeconfig, "  "))
+	loadbalancerConf  = fmt.Sprintf("kubeconfig: |\n%s\nloadBalancer:\n  enabled: %t\n  creationPollInterval: %d", indent(kubeconfig, "  "), false, 3)
+	instancesConf     = fmt.Sprintf("kubeconfig: |\n%s\ninstancesV2:\n  enabled: %t\n  enableInstanceTypes: %t", indent(kubeconfig, "  "), false, true)
+	zoneAndRegionConf = fmt.Sprintf("kubeconfig: |\n%s\ninstancesV2:\n  zoneAndRegionEnabled: %t\n  enableInstanceTypes: %t", indent(kubeconfig, "  "), false, true)
+	namespaceConf     = fmt.Sprintf("kubeconfig: |\n%s\nnamespace: %s", indent(kubeconfig, "  "), ns)
+	allConf           = fmt.Sprintf("kubeconfig: |\n%s\nloadBalancer:\n  enabled: %t\ninstancesV2:\n  enabled: %t\nnamespace: %s", indent(kubeconfig, "  "), false, false, ns)
+	invalidKubeconf   = "kubeconfig: bla"
 )
 
 func indent(s, indent string) string {
 	return indent + strings.ReplaceAll(s, "\n", fmt.Sprintf("\n%s", indent))
 }
 
-func makeCloudConfig(kubeconfig, namespace string, loadbalancerEnabled, instancesEnabled bool, lbCreationPollInterval int) CloudConfig {
+func makeCloudConfig(kubeconfig, namespace string, loadbalancerEnabled, instancesEnabled bool, zoneAndRegionEnabled bool, lbCreationPollInterval int) CloudConfig {
 	return CloudConfig{
 		Kubeconfig: kubeconfig,
 		LoadBalancer: LoadBalancerConfig{
@@ -52,7 +52,8 @@ func makeCloudConfig(kubeconfig, namespace string, loadbalancerEnabled, instance
 			CreationPollInterval: lbCreationPollInterval,
 		},
 		InstancesV2: InstancesV2Config{
-			Enabled: instancesEnabled,
+			Enabled:              instancesEnabled,
+			ZoneAndRegionEnabled: zoneAndRegionEnabled,
 		},
 		Namespace: namespace,
 	}
@@ -64,11 +65,12 @@ func TestNewCloudConfigFromBytes(t *testing.T) {
 		expectedCloudConfig CloudConfig
 		expectedError       error
 	}{
-		{minimalConf, makeCloudConfig(kubeconfig, "", true, true, 5), nil},
-		{loadbalancerConf, makeCloudConfig(kubeconfig, "", false, true, 3), nil},
-		{instancesConf, makeCloudConfig(kubeconfig, "", true, false, 5), nil},
-		{namespaceConf, makeCloudConfig(kubeconfig, ns, true, true, 5), nil},
-		{allConf, makeCloudConfig(kubeconfig, ns, false, false, 5), nil},
+		{minimalConf, makeCloudConfig(kubeconfig, "", true, true, true, 5), nil},
+		{loadbalancerConf, makeCloudConfig(kubeconfig, "", false, true, true, 3), nil},
+		{instancesConf, makeCloudConfig(kubeconfig, "", true, false, true, 5), nil},
+		{zoneAndRegionConf, makeCloudConfig(kubeconfig, "", true, true, false, 5), nil},
+		{namespaceConf, makeCloudConfig(kubeconfig, ns, true, true, true, 5), nil},
+		{allConf, makeCloudConfig(kubeconfig, ns, false, false, true, 5), nil},
 	}
 
 	for _, test := range tests {

--- a/pkg/provider/instances_v2.go
+++ b/pkg/provider/instances_v2.go
@@ -26,7 +26,7 @@ var providerIDRegexp = regexp.MustCompile(`^` + ProviderName + `://([0-9A-Za-z_-
 type instancesV2 struct {
 	namespace string
 	client    client.Client
-	config    InstancesV2Config
+	config    *InstancesV2Config
 }
 
 // InstanceExists returns true if the instance for the given node exists according to the cloud provider.
@@ -151,6 +151,10 @@ func (i *instancesV2) getNodeAddresses(ifs []kubevirtv1.VirtualMachineInstanceNe
 
 func (i *instancesV2) getRegionAndZone(ctx context.Context, nodeName string) (string, string, error) {
 	region, zone := "", ""
+	if i.config != nil && !i.config.ZoneAndRegionEnabled {
+		return region, zone, nil
+	}
+
 	node := corev1.Node{}
 
 	err := i.client.Get(ctx, client.ObjectKey{Name: nodeName}, &node)


### PR DESCRIPTION
This change is done in order to let the user option not to get this info
Currently, this info located in the Nodes, therefore it require the
controller to have Node get permission (cluster scope)
There is plane in kubevirt, to addopt this info also in the vmi,
which will allow to get this info without the Get Node permission
Related issue:
https://github.com/kubevirt/cloud-provider-kubevirt/issues/89

Fixes issue https://github.com/kubevirt/cloud-provider-kubevirt/issues/94