### PR TITLE
container: Storage golang deps at different layer

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ build: bin
 	CGO_ENABLED=0 GOOS=linux go build -ldflags="-s -w" -o bin/kubevirt-cloud-controller-manager ./cmd/kubevirt-cloud-controller-manager
 
 .PHONY:image
-image: build
+image:
 	docker build -t $(REGISTRY)/kubevirt-cloud-controller-manager:$(VERSION) -f build/images/kubevirt-cloud-controller-manager/Dockerfile .
 
 .PHONY: push

--- a/build/images/kubevirt-cloud-controller-manager/Dockerfile
+++ b/build/images/kubevirt-cloud-controller-manager/Dockerfile
@@ -1,9 +1,13 @@
 FROM --platform=linux/amd64 golang:1.17.11 AS builder
 
 WORKDIR /go/src/kubevirt.io/cloud-provider-kubevirt
-COPY . .
 
-RUN make build
+COPY go.* ./
+RUN go mod download
+
+COPY pkg/ pkg/
+COPY cmd/ cmd/
+RUN	CGO_ENABLED=0 GOOS=linux go build -ldflags="-s -w" -o bin/kubevirt-cloud-controller-manager ./cmd/kubevirt-cloud-controller-manager
 
 FROM registry.redhat.io/ubi9/ubi-micro
 COPY --from=builder /go/src/kubevirt.io/cloud-provider-kubevirt/bin/kubevirt-cloud-controller-manager /bin/kubevirt-cloud-controller-manager


### PR DESCRIPTION
When doing multistage without vendor directory is good to download first
the dependencies at different layer and then compile the code, this way
if code is changes only the layer that manage the compilation will have
to be reconstructed and deps will be download only once.
