### PR TITLE
Use public registry for ubi9/ubi-micro base image

### DIFF
--- a/build/images/kubevirt-cloud-controller-manager/Dockerfile
+++ b/build/images/kubevirt-cloud-controller-manager/Dockerfile
@@ -5,6 +5,6 @@ COPY . .
 
 RUN make build
 
-FROM registry.redhat.io/ubi9/ubi-micro
+FROM registry.access.redhat.com/ubi9/ubi-micro
 COPY --from=builder /go/src/kubevirt.io/cloud-provider-kubevirt/bin/kubevirt-cloud-controller-manager /bin/kubevirt-cloud-controller-manager
 ENTRYPOINT [ "/bin/kubevirt-cloud-controller-manager" ]


### PR DESCRIPTION
Use public registry `registry.access.redhat.com/ubi9/ubi-micro`
so that authentication is not required for building an image

Signed-off-by: Radim Hrazdil <rhrazdil@redhat.com>