### PR TITLE
kubevirtci: Prefix with cluster name

### DIFF
--- a/config/kubevirtci/kustomization.yaml
+++ b/config/kubevirtci/kustomization.yaml
@@ -2,5 +2,6 @@ namespace: kube-system
 bases: 
  - ../base
 
+namePrefix: kvcluster-
 patchesStrategicMerge:
   - manager_image_patch.yaml

--- a/kubevirtci
+++ b/kubevirtci
@@ -185,7 +185,7 @@ function kubevirtci::sync() {
 	$_ssh_infra node01  -- sudo cat  /etc/kubernetes/admin.conf > config/secret/infra-kubeconfig
 	$CLUSTERCTL_PATH get kubeconfig ${TENANT_CLUSTER_NAME} -n ${TENANT_CLUSTER_NAMESPACE} > config/secret/kubeconfig
 	${_kubectl} kustomize config/kubevirtci | ${_kubectl} apply -f -
-	${_kubectl} rollout status -w -n kube-system deployment/kubevirt-cloud-controller-manager
+	${_kubectl} rollout status -w -n kube-system deployment/${TENANT_CLUSTER_NAME}-kubevirt-cloud-controller-manager
 }
 
 function kubevirtci::delete() {


### PR DESCRIPTION
On a cluster with multiple tenant there have to be deployed multiple
cloud-provider-kubevirt resources. This change prefix them with the
cluster name so they don't collide.

Signed-off-by: Enrique Llorente <ellorent@redhat.com>