### PR TITLE
Fallback to in cluster kubeconfig

### DIFF
--- a/config/configmap/cloud-config
+++ b/config/configmap/cloud-config
@@ -1,4 +1,3 @@
-kubeconfig: /etc/kubernetes/infra-kubeconfig/infra-kubeconfig
 loadBalancer:
   creationPollInterval: 30
 namespace: kvcluster

--- a/config/kubevirtci/kustomization.yaml
+++ b/config/kubevirtci/kustomization.yaml
@@ -17,4 +17,4 @@ patchesJson6902:
     group: rbac.authorization.k8s.io
     version: v1
     kind: RoleBinding
-    name: kccm-extension-apiserver-authorization-reader
+    name: kccm

--- a/config/rbac/kccm_role.yaml
+++ b/config/rbac/kccm_role.yaml
@@ -1,0 +1,41 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  namespace: default
+  name: kccm
+rules:
+- apiGroups: 
+  - kubevirt.io
+  resources: 
+  - virtualmachines
+  verbs: 
+  - get
+  - watch
+  - list
+- apiGroups: 
+  - kubevirt.io
+  resources: 
+  - virtualmachineinstances
+  verbs: 
+  - get
+  - watch
+  - list
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - "*"
+- apiGroups:
+  - ""
+  resources:
+  - services
+  verbs:
+  - "*"
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - get

--- a/config/rbac/kccm_role_binding.yaml
+++ b/config/rbac/kccm_role_binding.yaml
@@ -1,0 +1,30 @@
+apiVersion: v1
+items:
+- apiVersion: rbac.authorization.k8s.io/v1
+  kind: RoleBinding
+  metadata: 
+    name: kccm
+    namespace: kube-system
+  roleRef:
+    apiGroup: rbac.authorization.k8s.io
+    kind: Role
+    name: extension-apiserver-authentication-reader
+  subjects:
+  - kind: ServiceAccount
+    name: cloud-controller-manager
+    namespace: default
+- apiVersion: rbac.authorization.k8s.io/v1
+  kind: RoleBinding
+  metadata: 
+    name: kccm-sa
+    namespace: default
+  roleRef:
+    apiGroup: rbac.authorization.k8s.io
+    kind: Role
+    name: kccm
+  subjects:
+  - kind: ServiceAccount
+    name: cloud-controller-manager
+    namespace: default
+kind: List
+metadata: {}

--- a/config/rbac/kustomization.yaml
+++ b/config/rbac/kustomization.yaml
@@ -1,3 +1,4 @@
 resources:
+- kccm_role_binding.yaml
+- kccm_role.yaml
 - service_account.yaml
-- ext_apiserver_auth_role_binding.yaml


### PR DESCRIPTION
If the cloud-config is missing the "kubeconfig" field use the InCluster
config to access infra.