### PR TITLE
e2e: sonobuoy k8s conformance tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -83,3 +83,7 @@ build-e2e-test:
 .PHONY: e2e-test
 e2e-test: build-e2e-test
 	./hack/run-e2e.sh
+
+.PHONY: conformance
+conformance:
+	./hack/conformance.sh

--- a/hack/conformance.sh
+++ b/hack/conformance.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+set -e -o pipefail
+
+export TENANT_CLUSTER_NAME=${TENANT_CLUSTER_NAME:-kvcluster}
+export TENANT_CLUSTER_NAMESPACE=${TENANT_CLUSTER_NAMESPACE:-kvcluster}
+export KUBECONFIG=$(./kubevirtci kubeconfig)
+
+sonobuoy_release="https://github.com/vmware-tanzu/sonobuoy/releases/download/v0.56.8/sonobuoy_0.56.8_linux_amd64.tar.gz"
+
+vms_list=$(kubectl get vm -n ${TENANT_CLUSTER_NAMESPACE} --no-headers -o custom-columns=":metadata.name")
+for vm in $vms_list; do
+    if [[ "$vm" == ${TENANT_CLUSTER_NAME}-control-plane* ]]; then
+            control_plane_vm_name=$vm
+    fi
+done
+
+if [ -n "${control_plane_vm_name}" ]; then
+    echo "Found control plane VM: ${control_plane_vm_name} in namespace ${TENANT_CLUSTER_NAMESPACE}"
+else
+    echo "control-plane vm is not found in namespace ${TENANT_CLUSTER_NAMESPACE} (looking for regex ${TENANT_CLUSTER_NAME}-control-plane*)"
+    exit 1
+fi
+
+./kubevirtci ssh-tenant $control_plane_vm_name $TENANT_CLUSTER_NAMESPACE -- \
+"sudo curl -L $sonobuoy_release -o sonobuoy.tar.gz && \
+tar -xzf sonobuoy.tar.gz && \
+chmod +x sonobuoy && \
+sudo KUBECONFIG=/etc/kubernetes/admin.conf ./sonobuoy run --plugin e2e --wait"
+trap './kubevirtci ssh-tenant $control_plane_vm_name $TENANT_CLUSTER_NAMESPACE -- "sudo KUBECONFIG=/etc/kubernetes/admin.conf ./sonobuoy delete"' EXIT SIGSTOP SIGKILL SIGTERM
+
+retrieve_file=$(./kubevirtci ssh-tenant $control_plane_vm_name $TENANT_CLUSTER_NAMESPACE -- "sudo KUBECONFIG=/etc/kubernetes/admin.conf ./sonobuoy retrieve" | tail -1 | awk '{ print $NF }')
+
+./kubevirtci scp-tenant $control_plane_vm_name $TENANT_CLUSTER_NAMESPACE $retrieve_file

--- a/kubevirtci
+++ b/kubevirtci
@@ -129,8 +129,8 @@ function kubevirtci::down() {
 }
 
 function kubevirtci::ssh_tenant() {
-	vmi_name=$1
-	vmi_namespace=${2:-$TENANT_CLUSTER_NAMESPACE}
+	vmi_name=$1 ; shift
+	vmi_namespace=${1:-$TENANT_CLUSTER_NAMESPACE} ; shift
 
 	mkdir -p $_default_tmp_path
 
@@ -140,9 +140,27 @@ function kubevirtci::ssh_tenant() {
 
 	chmod 600 ${_default_tmp_path}/key.pem
 
-	ssh -o IdentitiesOnly=yes -o "ProxyCommand=$_default_virtctl_path port-forward --stdio=true $vmi_name.$vmi_namespace 22" capk@$vmi_name.$vmi_namespace -i ${_default_tmp_path}/key.pem
+	ssh -o StrictHostKeyChecking=no -o IdentitiesOnly=yes -o "ProxyCommand=$_default_virtctl_path port-forward --stdio=true $vmi_name.$vmi_namespace 22" capk@$vmi_name.$vmi_namespace -i ${_default_tmp_path}/key.pem $@
 
 	rm ${_default_tmp_path}/key.pem
+}
+
+function kubevirtci::scp_tenant() {
+	vmi_name=$1 ; shift
+	vmi_namespace=${1:-$TENANT_CLUSTER_NAMESPACE} ; shift
+	file_path=$1 ; shift
+
+	mkdir -p $_default_tmp_path
+
+	echo "vmi $vmi_name namespace $vmi_namespace"
+
+	${_kubectl} get secret -n $TENANT_CLUSTER_NAMESPACE kvcluster-ssh-keys -o jsonpath='{.data}' 2> /dev/null | grep key | awk -F '"' '{print $4}' | base64 -d > ${_default_tmp_path}/scp_key.pem
+
+	chmod 600 ${_default_tmp_path}/scp_key.pem
+
+	scp -o StrictHostKeyChecking=no -o IdentitiesOnly=yes -o "ProxyCommand=$_default_virtctl_path port-forward --stdio=true $vmi_name.$vmi_namespace 22" -i ${_default_tmp_path}/scp_key.pem capk@$vmi_name.$vmi_namespace:$file_path $file_path
+
+	rm ${_default_tmp_path}/scp_key.pem
 }
 
 function kubevirtci::destroy_cluster() {
@@ -382,6 +400,9 @@ case ${_action} in
 		;;
 	"ssh-tenant")
 		kubevirtci::ssh_tenant "$@"
+		;;
+	"scp-tenant")
+		kubevirtci::scp_tenant "$@"
 		;;
 	"clusterctl")
 		$CLUSTERCTL_PATH "$@"


### PR DESCRIPTION
Signed-off-by: Radim Hrazdil <rhrazdil@redhat.com>

This PR adds a new Makefile target: `conformance`

Sonobuoy obtained and executed in tenant cluster to run default conformance test suite.
After the conformance suite finishes, results are retrieved with `scp-tenant` function added in `./kubevirtci`.

 