### PR TITLE
config,manager.yaml: remove volumeMounts for k8s certs

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -32,12 +32,6 @@ spec:
           requests:
             cpu: 100m
         volumeMounts:
-        - mountPath: /var/lib/kubelet/pki
-          name: k8s-certs
-          readOnly: true
-        - mountPath: /etc/ssl/certs
-          name: ca-certs
-          readOnly: true
         - mountPath: /etc/kubernetes/kubeconfig
           name: kubeconfig
           readOnly: true
@@ -45,14 +39,6 @@ spec:
           name: cloud-config
           readOnly: true
       volumes:
-      - hostPath:
-          path: /var/lib/kubelet/pki
-          type: DirectoryOrCreate
-        name: k8s-certs
-      - hostPath:
-          path: /etc/ssl/certs
-          type: DirectoryOrCreate
-        name: ca-certs
       - configMap:
           name: cloud-config
         name: cloud-config


### PR DESCRIPTION
Since we're running the kccm on the infra cluster, the volumeMounts
removed in this commit are now mounted from the infra cluster
nodes. But there should be no reason for mounting these certs.


Signed-off-by: Radim Hrazdil <rhrazdil@redhat.com>