### PR TITLE
go: Bump to 1.19

### DIFF
--- a/build/images/kubevirt-cloud-controller-manager/Dockerfile
+++ b/build/images/kubevirt-cloud-controller-manager/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 golang:1.17.11 AS builder
+FROM --platform=linux/amd64 golang:1.19 AS builder
 
 WORKDIR /go/src/kubevirt.io/cloud-provider-kubevirt
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module kubevirt.io/cloud-provider-kubevirt
 
-go 1.17
+go 1.19
 
 require (
 	github.com/golang/mock v1.6.0


### PR DESCRIPTION
To be able to bump cloud-provider dep we need to bump go to 1.19

Signed-off-by: Enrique Llorente <ellorent@redhat.com>