### PR TITLE
kustomize: Remove generated secret/cm suffix

### DIFF
--- a/config/base/kustomization.yaml
+++ b/config/base/kustomization.yaml
@@ -3,5 +3,8 @@ bases:
  - ../manager
  - ../secret
 
+generatorOptions:
+  disableNameSuffixHash: true
+
 patchesStrategicMerge:
 - manager_tenant_kubeconfig_secret_patch.yaml

--- a/config/overlays/default/kustomization.yaml
+++ b/config/overlays/default/kustomization.yaml
@@ -16,6 +16,9 @@ patchesJson6902:
     kind: RoleBinding
     name: kccm-extension-apiserver-authorization-reader
 
+generatorOptions:
+  disableNameSuffixHash: true
+
 configMapGenerator:
 - name: cloud-config
   namespace: default

--- a/config/overlays/isolated/kustomization.yaml
+++ b/config/overlays/isolated/kustomization.yaml
@@ -24,6 +24,9 @@ patchesStrategicMerge:
     name: kccm
   $patch: delete
 
+generatorOptions:
+  disableNameSuffixHash: true
+
 configMapGenerator:
 - name: cloud-config
   namespace: default


### PR DESCRIPTION
When kustomize generate the secrets and configmaps it prepend a suffix so they are keep after deploy, this is not needed for kccm. This change add a flag to disable that kustomize feature.