### PR TITLE
kustomize: Remove ref to kube-system isolated RBAC

### DIFF
--- a/config/isolated/kustomization.yaml
+++ b/config/isolated/kustomization.yaml
@@ -22,6 +22,13 @@ patchesStrategicMerge:
   metadata:
     name: kccm
   $patch: delete
+- |-
+  apiVersion: rbac.authorization.k8s.io/v1
+  kind: RoleBinding
+  metadata:
+    name: kccm
+    namespace: kube-system
+  $patch: delete
 
 generatorOptions:
   disableNameSuffixHash: true


### PR DESCRIPTION
When using kustomize isolated overlay the reference to kube-system is not needed, this change remove that at the isolated kustomization file.