### PR TITLE
kustomize, isolated: Remove nodes RBAC

### DIFF
--- a/config/isolated/kustomization.yaml
+++ b/config/isolated/kustomization.yaml
@@ -8,6 +8,13 @@ patches:
       value: --authentication-skip-lookup=true
   target:
     kind: Deployment
+- patch: |-
+    - op: remove
+      path: /rules/4
+  target:
+    kind: Role
+    name: kccm
+    namespace: default
 
 patchesStrategicMerge:
 - |-

--- a/config/rbac/kccm_role.yaml
+++ b/config/rbac/kccm_role.yaml
@@ -26,7 +26,9 @@ rules:
   resources:
   - pods
   verbs:
-  - "*"
+  - get
+  - list
+  - watch
 - apiGroups:
   - ""
   resources:


### PR DESCRIPTION
Nodes is not needed for isolated overlay since the node sync feature is deactivated at cloud-config.

This change also reduce the verbos for pods since update is not needed.