### PR TITLE
Allow podman to push images to the local insecure registry

### DIFF
--- a/kubevirtci
+++ b/kubevirtci
@@ -181,7 +181,15 @@ function kubevirtci::install_capk_release {
 
 function kubevirtci::sync() {
 
-	REGISTRY="127.0.0.1:$(cluster-up/cluster-up/cli.sh ports registry)" make image push
+	REGISTRY="127.0.0.1:$(cluster-up/cluster-up/cli.sh ports registry)"
+	if curl --unix-socket "/run/podman/podman.sock" http://d/v3.0.0/libpod/info >/dev/null 2>&1; then
+		cat <<EOF >> /etc/containers/registries.conf
+[[registry]]
+location = "$REGISTRY"
+insecure = true
+EOF
+	fi
+	REGISTRY=$REGISTRY make image push
 	$_ssh_infra node01  -- sudo cat  /etc/kubernetes/admin.conf > config/secret/infra-kubeconfig
 	$CLUSTERCTL_PATH get kubeconfig ${TENANT_CLUSTER_NAME} -n ${TENANT_CLUSTER_NAMESPACE} > config/secret/kubeconfig
 	${_kubectl} kustomize config/overlays/kubevirtci | ${_kubectl} apply -f -


### PR DESCRIPTION
The kubevirt CI infrastructure is moving to using a podman based bootstrap image rather than a docker in docker setup.

When running the pull-kubevirt-cloud-provider-kubevirt-e2e presubmit with podman, the job fails[1] as podman doe not allow pusgin to insecure registries by default[2].

This update will add the local insecure registry to registries.conf when the podman socket is available which will allow podman to push images to the registry.

[1] https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_project-infra/2359/rehearsal-pull-kubevirt-cloud-provider-kubevirt-e2e/1575140184981245952#1:build-log.txt%3A766 
[2] https://github.com/containers/podman/blob/main/troubleshooting.md#4-http-server-gave-http-response-to-https-client

/cc @qinqon @rhrazdil 

Signed-off-by: Brian Carey <bcarey@redhat.com>