### PR TITLE
Add id custom labels to infra Load balancers

### DIFF
--- a/pkg/provider/cloud.go
+++ b/pkg/provider/cloud.go
@@ -45,6 +45,7 @@ type CloudConfig struct {
 	LoadBalancer LoadBalancerConfig `yaml:"loadBalancer"`
 	InstancesV2  InstancesV2Config  `yaml:"instancesV2"`
 	Namespace    string             `yaml:"namespace"`
+	InfraLabels  map[string]string  `yaml:"infraLabels"`
 }
 
 type LoadBalancerConfig struct {
@@ -153,9 +154,10 @@ func (c *cloud) LoadBalancer() (cloudprovider.LoadBalancer, bool) {
 		return nil, false
 	}
 	return &loadbalancer{
-		namespace: c.namespace,
-		client:    c.client,
-		config:    c.config.LoadBalancer,
+		namespace:   c.namespace,
+		client:      c.client,
+		config:      c.config.LoadBalancer,
+		infraLabels: c.config.InfraLabels,
 	}, true
 }
 

--- a/pkg/provider/loadbalancer_test.go
+++ b/pkg/provider/loadbalancer_test.go
@@ -133,6 +133,7 @@ func generateInfraService(tenantSvc *corev1.Service, ports []corev1.ServicePort)
 			Labels: map[string]string{
 				"cluster.x-k8s.io/tenant-service-name":      tenantSvc.Name,
 				"cluster.x-k8s.io/tenant-service-namespace": tenantSvc.Namespace,
+				"cluster.x-k8s.io/cluster-name":             clusterName,
 			},
 			Annotations: tenantSvc.Annotations,
 		},


### PR DESCRIPTION
Using the cloud config, we should be able to add unique labels to the infra cluster load balancers which can help associating the LBs with cluster related resources (Like hypershift HostedClusters and NodePools)