### PR TITLE
lb: Add creation polling timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,8 @@ Output:
 ```yaml
 kubeconfig: <infraKubeConfigPath>
 loadBalancer:
-  creationPollInterval: 30
+  creationPollInterval: 5
+  creationPollTimeout: 60
 ```
 
 ## How to build a Docker image

--- a/config/default/cloud-config
+++ b/config/default/cloud-config
@@ -1,3 +1,4 @@
 loadBalancer:
-  creationPollInterval: 30
+  creationPollInterval: 5
+  creationPollTimeout: 60
 namespace: kvcluster

--- a/config/isolated/cloud-config
+++ b/config/isolated/cloud-config
@@ -1,5 +1,6 @@
 loadBalancer:
-  creationPollInterval: 30
+  creationPollInterval: 5
+  creationPollTimeout: 60
 namespace: kvcluster
 instancesV2:
   enabled: true

--- a/pkg/provider/cloud.go
+++ b/pkg/provider/cloud.go
@@ -13,6 +13,7 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 	cloudprovider "k8s.io/cloud-provider"
 	"k8s.io/klog/v2"
+	"k8s.io/utils/pointer"
 	kubevirtv1 "kubevirt.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -51,8 +52,12 @@ type CloudConfig struct {
 type LoadBalancerConfig struct {
 	// Enabled activates the load balancer interface of the CCM
 	Enabled bool `yaml:"enabled"`
-	// CreationPollInterval determines how many seconds to wait for the load balancer creation
-	CreationPollInterval int `yaml:"creationPollInterval"`
+
+	// CreationPollInterval determines how many seconds to wait for the load balancer creation between retries
+	CreationPollInterval *int `yaml:"creationPollInterval,omitempty"`
+
+	// CreationPollTimeout determines how many seconds to wait for the load balancer creation
+	CreationPollTimeout *int `yaml:"creationPollTimeout,omitempty"`
 }
 
 type InstancesV2Config struct {
@@ -68,7 +73,8 @@ func createDefaultCloudConfig() CloudConfig {
 	return CloudConfig{
 		LoadBalancer: LoadBalancerConfig{
 			Enabled:              true,
-			CreationPollInterval: defaultLoadBalancerCreatePollInterval,
+			CreationPollInterval: pointer.Int(int(defaultLoadBalancerCreatePollInterval.Seconds())),
+			CreationPollTimeout:  pointer.Int(int(defaultLoadBalancerCreatePollTimeout.Seconds())),
 		},
 		InstancesV2: InstancesV2Config{
 			Enabled:              true,

--- a/pkg/provider/cloud_test.go
+++ b/pkg/provider/cloud_test.go
@@ -14,7 +14,7 @@ var (
 	ns                  = "aNamespace"
 	infraKubeConfigPath = "infraKubeConfig"
 	minimalConf         = fmt.Sprintf("kubeconfig: %s", infraKubeConfigPath)
-	loadbalancerConf    = fmt.Sprintf("kubeconfig: %s\nloadBalancer:\n  enabled: %t\n  creationPollInterval: %d", infraKubeConfigPath, false, 3)
+	loadbalancerConf    = fmt.Sprintf("kubeconfig: %s\nloadBalancer:\n  enabled: %t\n  creationPollInterval: %d\n  creationPollTimeout: %d", infraKubeConfigPath, false, 3, 100)
 	instancesConf       = fmt.Sprintf("kubeconfig: %s\ninstancesV2:\n  enabled: %t\n  enableInstanceTypes: %t", infraKubeConfigPath, false, true)
 	zoneAndRegionConf   = fmt.Sprintf("kubeconfig: %s\ninstancesV2:\n  zoneAndRegionEnabled: %t\n  enableInstanceTypes: %t", infraKubeConfigPath, false, true)
 	namespaceConf       = fmt.Sprintf("kubeconfig: %s\nnamespace: %s", infraKubeConfigPath, ns)
@@ -22,12 +22,13 @@ var (
 	invalidKubeconf     = "bla"
 )
 
-func makeCloudConfig(kubeconfig, namespace string, loadbalancerEnabled, instancesEnabled bool, zoneAndRegionEnabled bool, lbCreationPollInterval int) CloudConfig {
+func makeCloudConfig(kubeconfig, namespace string, loadbalancerEnabled, instancesEnabled bool, zoneAndRegionEnabled bool, lbCreationPollInterval int, lbCreationPollTimeout int) CloudConfig {
 	return CloudConfig{
 		Kubeconfig: kubeconfig,
 		LoadBalancer: LoadBalancerConfig{
 			Enabled:              loadbalancerEnabled,
-			CreationPollInterval: lbCreationPollInterval,
+			CreationPollInterval: &lbCreationPollInterval,
+			CreationPollTimeout:  &lbCreationPollTimeout,
 		},
 		InstancesV2: InstancesV2Config{
 			Enabled:              instancesEnabled,
@@ -44,12 +45,12 @@ var _ = Describe("Cloud config", func() {
 		Expect(config).To(Equal(expectedCloudConfig))
 		Expect(err).To(BeNil())
 	},
-		Entry("With minimal configuration", minimalConf, makeCloudConfig(infraKubeConfigPath, "", true, true, true, 5), nil),
-		Entry("With loadBalancer configuration", loadbalancerConf, makeCloudConfig(infraKubeConfigPath, "", false, true, true, 3), nil),
-		Entry("With instance configuration", instancesConf, makeCloudConfig(infraKubeConfigPath, "", true, false, true, 5), nil),
-		Entry("With zone and region configuration", zoneAndRegionConf, makeCloudConfig(infraKubeConfigPath, "", true, true, false, 5), nil),
-		Entry("With namespace configuration", namespaceConf, makeCloudConfig(infraKubeConfigPath, ns, true, true, true, 5), nil),
-		Entry("With full configuration", allConf, makeCloudConfig(infraKubeConfigPath, ns, false, false, true, 5), nil),
+		Entry("With minimal configuration", minimalConf, makeCloudConfig(infraKubeConfigPath, "", true, true, true, 5, 300), nil),
+		Entry("With loadBalancer configuration", loadbalancerConf, makeCloudConfig(infraKubeConfigPath, "", false, true, true, 3, 100), nil),
+		Entry("With instance configuration", instancesConf, makeCloudConfig(infraKubeConfigPath, "", true, false, true, 5, 300), nil),
+		Entry("With zone and region configuration", zoneAndRegionConf, makeCloudConfig(infraKubeConfigPath, "", true, true, false, 5, 300), nil),
+		Entry("With namespace configuration", namespaceConf, makeCloudConfig(infraKubeConfigPath, ns, true, true, true, 5, 300), nil),
+		Entry("With full configuration", allConf, makeCloudConfig(infraKubeConfigPath, ns, false, false, true, 5, 300), nil),
 	)
 
 	Describe("KubeVirt Cloud Factory", func() {


### PR DESCRIPTION
Add a polling timeout at infra service creation to fail if services do not receive IPs after a period of time.

This will fail in cases where the lb provider has no more IPs or if there are failures like AWS not supporting multi protocol.

If the loop is not broken kccm is stuck and no more services will be created.

Closes: https://issues.redhat.com/browse/OCPBUGS-15055