### PR TITLE
lb: Add selectorless config flag

### DIFF
--- a/pkg/provider/cloud.go
+++ b/pkg/provider/cloud.go
@@ -58,6 +58,10 @@ type LoadBalancerConfig struct {
 
 	// CreationPollTimeout determines how many seconds to wait for the load balancer creation
 	CreationPollTimeout *int `yaml:"creationPollTimeout,omitempty"`
+
+	// Selectorless delegate endpointslices creation on third party by
+	// skipping service selector creation
+	Selectorless *bool `yaml:"selectorless,omitempty"`
 }
 
 type InstancesV2Config struct {

--- a/pkg/provider/loadbalancer.go
+++ b/pkg/provider/loadbalancer.go
@@ -198,10 +198,12 @@ func (lb *loadbalancer) createLoadBalancerService(ctx context.Context, lbName st
 		},
 		Spec: corev1.ServiceSpec{
 			Ports:                 ports,
-			Selector:              vmiLabels,
 			Type:                  corev1.ServiceTypeLoadBalancer,
 			ExternalTrafficPolicy: service.Spec.ExternalTrafficPolicy,
 		},
+	}
+	if lb.config.Selectorless == nil || !*lb.config.Selectorless {
+		lbService.Spec.Selector = vmiLabels
 	}
 	if len(service.Spec.ExternalIPs) > 0 {
 		lbService.Spec.ExternalIPs = service.Spec.ExternalIPs


### PR DESCRIPTION
**What this PR does / why we need it**:
For kubevirt virtualmachines without pod networking with just multus secondary networks the generated endpointslices from the service selector are of no use since they are point to the virt-launcher pod that do not point to any VM.

This change add a flag to the lb config so users can skip the lb service selector generation and create their own endpointslices pointing to the secondary network IPs.

```release-note
Add selectorless load balancer config flag
```
