### PR TITLE
fix deprecated kustomize key

### DIFF
--- a/config/base/kustomization.yaml
+++ b/config/base/kustomization.yaml
@@ -1,3 +1,5 @@
-bases: 
- - ../rbac
- - ../manager
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ../rbac
+- ../manager

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -1,7 +1,18 @@
-bases: 
- - ../base
 
-patchesJson6902:
+
+generatorOptions:
+  disableNameSuffixHash: true
+
+configMapGenerator:
+- files:
+  - cloud-config
+  name: cloud-config
+  namespace: default
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ../base
+patches:
 - patch: |-
     - op: add
       path: /metadata/namespace
@@ -11,15 +22,6 @@ patchesJson6902:
       value: default
   target:
     group: rbac.authorization.k8s.io
-    version: v1
     kind: RoleBinding
     name: kccm-extension-apiserver-authorization-reader
-
-generatorOptions:
-  disableNameSuffixHash: true
-
-configMapGenerator:
-- name: cloud-config
-  namespace: default
-  files:
-  - cloud-config
+    version: v1

--- a/config/isolated/kustomization.yaml
+++ b/config/isolated/kustomization.yaml
@@ -1,5 +1,3 @@
-bases: 
- - ../base
 
 patches:
 - patch: |-
@@ -15,33 +13,36 @@ patches:
     kind: Role
     name: kccm
     namespace: default
+- patch: |-
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRole
+    metadata:
+      name: kccm
+    $patch: delete
+- patch: |-
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRoleBinding
+    metadata:
+      name: kccm
+    $patch: delete
+- patch: |-
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: RoleBinding
+    metadata:
+      name: kccm
+      namespace: kube-system
+    $patch: delete
 
-patchesStrategicMerge:
-- |-
-  apiVersion: rbac.authorization.k8s.io/v1
-  kind: ClusterRole
-  metadata:
-    name: kccm
-  $patch: delete
-- |-
-  apiVersion: rbac.authorization.k8s.io/v1
-  kind: ClusterRoleBinding
-  metadata:
-    name: kccm
-  $patch: delete
-- |-
-  apiVersion: rbac.authorization.k8s.io/v1
-  kind: RoleBinding
-  metadata:
-    name: kccm
-    namespace: kube-system
-  $patch: delete
 
 generatorOptions:
   disableNameSuffixHash: true
 
 configMapGenerator:
-- name: cloud-config
-  namespace: default
-  files:
+- files:
   - cloud-config
+  name: cloud-config
+  namespace: default
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ../base

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -1,2 +1,4 @@
 resources:
 - manager.yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization

--- a/config/overlays/default/kustomization.yaml
+++ b/config/overlays/default/kustomization.yaml
@@ -1,3 +1,5 @@
-bases:
-  - ../../secret 
-  - ../../default
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ../../secret
+- ../../default

--- a/config/overlays/isolated/kustomization.yaml
+++ b/config/overlays/isolated/kustomization.yaml
@@ -1,3 +1,5 @@
-bases:
-  - ../../secret 
-  - ../../isolated
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ../../secret
+- ../../isolated

--- a/config/overlays/kubevirtci/kustomization.yaml
+++ b/config/overlays/kubevirtci/kustomization.yaml
@@ -1,10 +1,5 @@
 namespace: kvcluster
-bases: 
-- ../../secret
-- ../../isolated
 
-patchesStrategicMerge:
-- manager_image_patch.yaml
 
 patches:
 - patch: |-
@@ -13,3 +8,9 @@ patches:
       value: --cluster-name=$TENANT_CLUSTER_NAME
   target:
     kind: Deployment
+- path: manager_image_patch.yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ../../secret
+- ../../isolated

--- a/config/rbac/kustomization.yaml
+++ b/config/rbac/kustomization.yaml
@@ -4,3 +4,5 @@ resources:
 - kccm_cluster_role_binding.yaml
 - kccm_role.yaml
 - kccm_role_binding.yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization

--- a/config/secret/kustomization.yaml
+++ b/config/secret/kustomization.yaml
@@ -2,7 +2,9 @@ generatorOptions:
   disableNameSuffixHash: true
 
 secretGenerator:
-- name: kubeconfig
-  namespace: default
-  files:
+- files:
   - kubeconfig
+  name: kubeconfig
+  namespace: default
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

While i build install.yaml with kustomize, it will be warning like this:

```
# Warning: 'bases' is deprecated. Please use 'resources' instead. Run 'kustomize edit fix' to update your Kustomization automatically.
# Warning: 'patchesJson6902' is deprecated. Please use 'patches' instead. Run 'kustomize edit fix' to update your Kustomization automatically.
# Warning: 'bases' is deprecated. Please use 'resources' instead. Run 'kustomize edit fix' to update your Kustomization automatically.
```

This patch fixed the warning.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
