### PR TITLE
Add support for reconciling and restoring infra EndpointSlices

### DIFF
--- a/pkg/controller/kubevirteps/kubevirteps_controller.go
+++ b/pkg/controller/kubevirteps/kubevirteps_controller.go
@@ -108,32 +108,24 @@ func newRequest(reqType ReqType, obj interface{}, oldObj interface{}) *Request {
 }
 
 func (c *Controller) Init() error {
-
-	// Act on events from Services on the infra cluster. These are created by the EnsureLoadBalancer function.
-	// We need to watch for these events so that we can update the EndpointSlices in the infra cluster accordingly.
+	// Existing Service event handlers...
 	_, err := c.infraFactory.Core().V1().Services().Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc: func(obj interface{}) {
-			// cast obj to Service
 			svc := obj.(*v1.Service)
-			// Only act on Services of type LoadBalancer
 			if svc.Spec.Type == v1.ServiceTypeLoadBalancer {
 				klog.Infof("Service added: %v/%v", svc.Namespace, svc.Name)
 				c.queue.Add(newRequest(AddReq, obj, nil))
 			}
 		},
 		UpdateFunc: func(oldObj, newObj interface{}) {
-			// cast obj to Service
 			newSvc := newObj.(*v1.Service)
-			// Only act on Services of type LoadBalancer
 			if newSvc.Spec.Type == v1.ServiceTypeLoadBalancer {
 				klog.Infof("Service updated: %v/%v", newSvc.Namespace, newSvc.Name)
 				c.queue.Add(newRequest(UpdateReq, newObj, oldObj))
 			}
 		},
 		DeleteFunc: func(obj interface{}) {
-			// cast obj to Service
 			svc := obj.(*v1.Service)
-			// Only act on Services of type LoadBalancer
 			if svc.Spec.Type == v1.ServiceTypeLoadBalancer {
 				klog.Infof("Service deleted: %v/%v", svc.Namespace, svc.Name)
 				c.queue.Add(newRequest(DeleteReq, obj, nil))
@@ -144,7 +136,7 @@ func (c *Controller) Init() error {
 		return err
 	}
 
-	// Monitor endpoint slices that we are interested in based on known services in the infra cluster
+	// Existing EndpointSlice event handlers in tenant cluster...
 	_, err = c.tenantFactory.Discovery().V1().EndpointSlices().Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc: func(obj interface{}) {
 			eps := obj.(*discovery.EndpointSlice)
@@ -194,8 +186,78 @@ func (c *Controller) Init() error {
 		return err
 	}
 
-	//TODO: Add informer for EndpointSlices in the infra cluster to watch for (unwanted) changes
+	// Add an informer for EndpointSlices in the infra cluster
+	_, err = c.infraFactory.Discovery().V1().EndpointSlices().Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc: func(obj interface{}) {
+			eps := obj.(*discovery.EndpointSlice)
+			if c.managedByController(eps) {
+				svc, svcErr := c.getInfraServiceForEPS(context.TODO(), eps)
+				if svcErr != nil {
+					klog.Errorf("Failed to get infra Service for EndpointSlice %s/%s: %v", eps.Namespace, eps.Name, svcErr)
+					return
+				}
+				if svc != nil {
+					klog.Infof("Infra EndpointSlice added: %v/%v, requeuing Service: %v/%v", eps.Namespace, eps.Name, svc.Namespace, svc.Name)
+					c.queue.Add(newRequest(AddReq, svc, nil))
+				}
+			}
+		},
+		UpdateFunc: func(oldObj, newObj interface{}) {
+			eps := newObj.(*discovery.EndpointSlice)
+			if c.managedByController(eps) {
+				svc, svcErr := c.getInfraServiceForEPS(context.TODO(), eps)
+				if svcErr != nil {
+					klog.Errorf("Failed to get infra Service for EndpointSlice %s/%s: %v", eps.Namespace, eps.Name, svcErr)
+					return
+				}
+				if svc != nil {
+					klog.Infof("Infra EndpointSlice updated: %v/%v, requeuing Service: %v/%v", eps.Namespace, eps.Name, svc.Namespace, svc.Name)
+					c.queue.Add(newRequest(UpdateReq, svc, nil))
+				}
+			}
+		},
+		DeleteFunc: func(obj interface{}) {
+			eps := obj.(*discovery.EndpointSlice)
+			if c.managedByController(eps) {
+				svc, svcErr := c.getInfraServiceForEPS(context.TODO(), eps)
+				if svcErr != nil {
+					klog.Errorf("Failed to get infra Service for EndpointSlice %s/%s on delete: %v", eps.Namespace, eps.Name, svcErr)
+					return
+				}
+				if svc != nil {
+					klog.Infof("Infra EndpointSlice deleted: %v/%v, requeuing Service: %v/%v", eps.Namespace, eps.Name, svc.Namespace, svc.Name)
+					c.queue.Add(newRequest(DeleteReq, svc, nil))
+				}
+			}
+		},
+	})
+	if err != nil {
+		return err
+	}
+
 	return nil
+}
+
+// getInfraServiceForEPS returns the Service in the infra cluster associated with the given EndpointSlice.
+// It does this by reading the "kubernetes.io/service-name" label from the EndpointSlice, which should correspond
+// to the Service name. If not found or if the Service doesn't exist, it returns nil.
+func (c *Controller) getInfraServiceForEPS(ctx context.Context, eps *discovery.EndpointSlice) (*v1.Service, error) {
+	svcName := eps.Labels[discovery.LabelServiceName]
+	if svcName == "" {
+		// No service name label found, can't determine infra service.
+		return nil, nil
+	}
+
+	svc, err := c.infraClient.CoreV1().Services(c.infraNamespace).Get(ctx, svcName, metav1.GetOptions{})
+	if err != nil {
+		if k8serrors.IsNotFound(err) {
+			// Service doesn't exist
+			return nil, nil
+		}
+		return nil, err
+	}
+
+	return svc, nil
 }
 
 // Run starts an asynchronous loop that monitors and updates GKENetworkParamSet in the cluster.


### PR DESCRIPTION
This PR introduces the following key changes to the `kubevirteps` controller:

- **Added infra EndpointSlice Informer**: The controller now watches for `EndpointSlice` events (add, update, delete) in the infra cluster.
- **Reconciliation on EndpointSlice deletion**: The controller detects when an infra `EndpointSlice` is deleted and automatically re-queues the associated Service for reconciliation.
- **Refactored `reconcile` logic**: Improved the `getInfraServiceForEPS` function to map `EndpointSlices` back to their associated infra `Services` using labels.
- **Enhanced tests**:
  - Verified restoration of infra `EndpointSlice` after manual deletion.
  - Ensured correct handling of Services with multiple unique ports.
  - Covered scenarios for updating `EndpointSlices` when associated `Services` are modified.

These improvements enhance the controller's resilience and ensure that infra `EndpointSlices` are consistently in sync with the desired state.
