### PR TITLE
Add fallback to all VMIs when endpoints lack NodeName

### DIFF
--- a/pkg/controller/kubevirteps/kubevirteps_controller.go
+++ b/pkg/controller/kubevirteps/kubevirteps_controller.go
@@ -665,15 +665,24 @@ func (c *Controller) getDesiredEndpoints(service *v1.Service, tenantSlices []*di
 		// for extracting the nodes it does not matter what type of address we are dealing with
 		// all nodes with an endpoint for a corresponding slice will be selected.
 		nodeSet := sets.Set[string]{}
+		hasEndpointsWithoutNodeName := false
 		for _, slice := range tenantSlices {
 			for _, endpoint := range slice.Endpoints {
 				// find all unique nodes that correspond to an endpoint in a tenant slice
 				if endpoint.NodeName == nil {
 					klog.Warningf("Skipping endpoint without NodeName in slice %s/%s", slice.Namespace, slice.Name)
+					hasEndpointsWithoutNodeName = true
 					continue
 				}
 				nodeSet.Insert(*endpoint.NodeName)
 			}
+		}
+
+		// Fallback: if no endpoints with NodeName were found, but there are endpoints without NodeName,
+		// distribute traffic to all VMIs (similar to ExternalTrafficPolicy=Cluster behavior)
+		if nodeSet.Len() == 0 && hasEndpointsWithoutNodeName {
+			klog.Infof("No endpoints with NodeName found for service %s/%s, falling back to all VMIs", service.Namespace, service.Name)
+			return c.getAllVMIEndpoints()
 		}
 
 		klog.Infof("Desired nodes for service %s/%s: %v", service.Namespace, service.Name, sets.List(nodeSet))
@@ -728,6 +737,64 @@ func (c *Controller) getDesiredEndpoints(service *v1.Service, tenantSlices []*di
 	}
 
 	return desiredEndpoints
+}
+
+// getAllVMIEndpoints returns endpoints for all VMIs in the infra namespace.
+// This is used as a fallback when tenant endpoints don't have NodeName specified,
+// similar to ExternalTrafficPolicy=Cluster behavior where traffic is distributed to all nodes.
+func (c *Controller) getAllVMIEndpoints() []*discovery.Endpoint {
+	var endpoints []*discovery.Endpoint
+
+	// List all VMIs in the infra namespace
+	vmiList, err := c.infraDynamic.
+		Resource(kubevirtv1.VirtualMachineInstanceGroupVersionKind.GroupVersion().WithResource("virtualmachineinstances")).
+		Namespace(c.infraNamespace).
+		List(context.TODO(), metav1.ListOptions{})
+	if err != nil {
+		klog.Errorf("Failed to list VMIs in namespace %q: %v", c.infraNamespace, err)
+		return endpoints
+	}
+
+	for _, obj := range vmiList.Items {
+		vmi := &kubevirtv1.VirtualMachineInstance{}
+		err = runtime.DefaultUnstructuredConverter.FromUnstructured(obj.Object, vmi)
+		if err != nil {
+			klog.Errorf("Failed to convert Unstructured to VirtualMachineInstance: %v", err)
+			continue
+		}
+
+		if vmi.Status.NodeName == "" {
+			klog.Warningf("Skipping VMI %s/%s: NodeName is empty", vmi.Namespace, vmi.Name)
+			continue
+		}
+		nodeNamePtr := &vmi.Status.NodeName
+
+		ready := vmi.Status.Phase == kubevirtv1.Running
+		serving := vmi.Status.Phase == kubevirtv1.Running
+		terminating := vmi.Status.Phase == kubevirtv1.Failed || vmi.Status.Phase == kubevirtv1.Succeeded
+
+		for _, i := range vmi.Status.Interfaces {
+			if i.Name == "default" {
+				if i.IP == "" {
+					klog.Warningf("VMI %s/%s interface %q has no IP, skipping", vmi.Namespace, vmi.Name, i.Name)
+					continue
+				}
+				endpoints = append(endpoints, &discovery.Endpoint{
+					Addresses: []string{i.IP},
+					Conditions: discovery.EndpointConditions{
+						Ready:       &ready,
+						Serving:     &serving,
+						Terminating: &terminating,
+					},
+					NodeName: nodeNamePtr,
+				})
+				break
+			}
+		}
+	}
+
+	klog.Infof("Fallback: created %d endpoints from all VMIs in namespace %s", len(endpoints), c.infraNamespace)
+	return endpoints
 }
 
 func (c *Controller) ensureEndpointSliceLabels(slice *discovery.EndpointSlice, svc *v1.Service) (map[string]string, bool) {

--- a/pkg/controller/kubevirteps/kubevirteps_controller.go
+++ b/pkg/controller/kubevirteps/kubevirteps_controller.go
@@ -12,7 +12,6 @@ import (
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
@@ -669,28 +668,39 @@ func (c *Controller) getDesiredEndpoints(service *v1.Service, tenantSlices []*di
 		for _, slice := range tenantSlices {
 			for _, endpoint := range slice.Endpoints {
 				// find all unique nodes that correspond to an endpoint in a tenant slice
+				if endpoint.NodeName == nil {
+					klog.Warningf("Skipping endpoint without NodeName in slice %s/%s", slice.Namespace, slice.Name)
+					continue
+				}
 				nodeSet.Insert(*endpoint.NodeName)
 			}
 		}
 
-		klog.Infof("Desired nodes for service %s in namespace %s: %v", service.Name, service.Namespace, sets.List(nodeSet))
+		klog.Infof("Desired nodes for service %s/%s: %v", service.Namespace, service.Name, sets.List(nodeSet))
 
 		for _, node := range sets.List(nodeSet) {
 			// find vmi for node name
-			obj := &unstructured.Unstructured{}
-			vmi := &kubevirtv1.VirtualMachineInstance{}
-
-			obj, err := c.infraDynamic.Resource(kubevirtv1.VirtualMachineInstanceGroupVersionKind.GroupVersion().WithResource("virtualmachineinstances")).Namespace(c.infraNamespace).Get(context.TODO(), node, metav1.GetOptions{})
+			obj, err := c.infraDynamic.
+				Resource(kubevirtv1.VirtualMachineInstanceGroupVersionKind.GroupVersion().WithResource("virtualmachineinstances")).
+				Namespace(c.infraNamespace).
+				Get(context.TODO(), node, metav1.GetOptions{})
 			if err != nil {
-				klog.Errorf("Failed to get VirtualMachineInstance %s in namespace %s:%v", node, c.infraNamespace, err)
+				klog.Errorf("Failed to get VMI %q in namespace %q: %v", node, c.infraNamespace, err)
 				continue
 			}
 
+			vmi := &kubevirtv1.VirtualMachineInstance{}
 			err = runtime.DefaultUnstructuredConverter.FromUnstructured(obj.Object, vmi)
 			if err != nil {
 				klog.Errorf("Failed to convert Unstructured to VirtualMachineInstance: %v", err)
-				klog.Fatal(err)
+				continue
 			}
+
+			if vmi.Status.NodeName == "" {
+				klog.Warningf("Skipping VMI %s/%s: NodeName is empty", vmi.Namespace, vmi.Name)
+				continue
+			}
+			nodeNamePtr := &vmi.Status.NodeName
 
 			ready := vmi.Status.Phase == kubevirtv1.Running
 			serving := vmi.Status.Phase == kubevirtv1.Running
@@ -698,6 +708,10 @@ func (c *Controller) getDesiredEndpoints(service *v1.Service, tenantSlices []*di
 
 			for _, i := range vmi.Status.Interfaces {
 				if i.Name == "default" {
+					if i.IP == "" {
+						klog.Warningf("VMI %s/%s interface %q has no IP, skipping", vmi.Namespace, vmi.Name, i.Name)
+						continue
+					}
 					desiredEndpoints = append(desiredEndpoints, &discovery.Endpoint{
 						Addresses: []string{i.IP},
 						Conditions: discovery.EndpointConditions{
@@ -705,9 +719,9 @@ func (c *Controller) getDesiredEndpoints(service *v1.Service, tenantSlices []*di
 							Serving:     &serving,
 							Terminating: &terminating,
 						},
-						NodeName: &vmi.Status.NodeName,
+						NodeName: nodeNamePtr,
 					})
-					continue
+					break
 				}
 			}
 		}

--- a/pkg/controller/kubevirteps/kubevirteps_controller_test.go
+++ b/pkg/controller/kubevirteps/kubevirteps_controller_test.go
@@ -771,3 +771,55 @@ var _ = g.Describe("KubevirtEPSController", g.Ordered, func() {
 
 	})
 })
+
+var _ = g.Describe("getDesiredEndpoints", func() {
+	g.It("should skip endpoints without NodeName and VMIs without NodeName or IP", func() {
+		// Setup controller
+		ctrl := setupTestKubevirtEPSController().controller
+
+		// Manually inject dynamic client content (1 VMI with missing NodeName)
+		vmi := createUnstructuredVMINode("vmi-without-node", "", "10.0.0.1") // empty NodeName
+		_, err := ctrl.infraDynamic.
+			Resource(kubevirtv1.VirtualMachineInstanceGroupVersionKind.GroupVersion().WithResource("virtualmachineinstances")).
+			Namespace(infraNamespace).
+			Create(context.TODO(), vmi, metav1.CreateOptions{})
+		Expect(err).To(BeNil())
+
+		// Create service
+		svc := createInfraServiceLB("test-svc", "test-svc", "test-cluster",
+			v1.ServicePort{
+				Name:       "http",
+				Port:       80,
+				TargetPort: intstr.FromInt(8080),
+				Protocol:   v1.ProtocolTCP,
+			},
+			v1.ServiceExternalTrafficPolicyLocal,
+		)
+
+		// One endpoint has nil NodeName, another is valid
+		nodeName := "vmi-without-node"
+		tenantSlice := &discoveryv1.EndpointSlice{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "slice",
+				Namespace: tenantNamespace,
+				Labels: map[string]string{
+					discoveryv1.LabelServiceName: "test-svc",
+				},
+			},
+			AddressType: discoveryv1.AddressTypeIPv4,
+			Endpoints: []discoveryv1.Endpoint{
+				{ // should be skipped due to nil NodeName
+					Addresses: []string{"10.1.1.1"},
+					NodeName:  nil,
+				},
+				{ // will hit VMI without NodeName and also be skipped
+					Addresses: []string{"10.1.1.2"},
+					NodeName:  &nodeName,
+				},
+			},
+		}
+
+		endpoints := ctrl.getDesiredEndpoints(svc, []*discoveryv1.EndpointSlice{tenantSlice})
+		Expect(endpoints).To(HaveLen(0), "Expected no endpoints due to missing NodeName or IP")
+	})
+})


### PR DESCRIPTION
This PR also includes fix from
- https://github.com/kubevirt/cloud-provider-kubevirt/pull/354

## Problem

Cilium Envoy Gateway creates EndpointSlices without NodeName field, which causes the kubevirt EPS controller to skip these endpoints. This results in services not being published properly.

Example error:
```
W1216 08:51:40.408047       1 kubevirteps_controller.go:795] Skipping endpoint without NodeName in slice grafana/cilium-gateway-grafana-gateway-vmm5w
```

The endpoint IP (e.g., 192.192.192.192) is only accessible within KubeVirt VM nodes, so we need to distribute traffic to all VMIs via NodePort.

## Solution

This PR adds a fallback mechanism:
- When no endpoints with NodeName are found, but there are endpoints without NodeName
- The controller distributes traffic to all VMIs in the infra namespace
- This is similar to ExternalTrafficPolicy=Cluster behavior

## Changes

- Added `hasEndpointsWithoutNodeName` flag to track endpoints without NodeName
- Added fallback logic in `getDesiredEndpoints()` to use all VMIs when needed
- Implemented `getAllVMIEndpoints()` function that lists all VMIs and creates endpoints for them

## Testing

Tested with Cilium Gateway EndpointSlices that don't have NodeName field.