### PR TITLE
Support predictable load balancer service naming

### DIFF
--- a/pkg/provider/cloud.go
+++ b/pkg/provider/cloud.go
@@ -67,6 +67,13 @@ type LoadBalancerConfig struct {
 	// This is a temporary flag to enable/disable the EPS controller
 	// When disabled the service selector is used.
 	EnableEPSController *bool `yaml:"enableEPSController,omitempty"`
+
+	// NamingStrategy controls how infrastructure load balancer services are named.
+	// "semantic" generates predictable names from cluster, namespace, and service name
+	// (e.g. "mycluster-default-nginx"). Can be overridden per-service with the
+	// kubevirt.io/set-loadbalancer-name annotation.
+	// "legacy" (default) uses the deprecated Kubernetes UID-based naming.
+	NamingStrategy string `yaml:"namingStrategy,omitempty"`
 }
 
 type InstancesV2Config struct {

--- a/pkg/provider/loadbalancer.go
+++ b/pkg/provider/loadbalancer.go
@@ -2,6 +2,10 @@ package provider
 
 import (
 	"context"
+	"crypto/sha256"
+	"fmt"
+	"regexp"
+	"strings"
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
@@ -26,6 +30,17 @@ const (
 	TenantServiceNamespaceLabelKey = "cluster.x-k8s.io/tenant-service-namespace"
 	TenantClusterNameLabelKey      = "cluster.x-k8s.io/cluster-name"
 	TenantNodeRoleLabelKey         = "cluster.x-k8s.io/role"
+
+	// LoadBalancerNameAnnotation allows overriding the generated load balancer name
+	LoadBalancerNameAnnotation = "kubevirt.io/set-loadbalancer-name"
+
+	// maxServiceNameLength is the maximum length for a Kubernetes service name
+	maxServiceNameLength = 63
+)
+
+var (
+	nonDNSCharsRegexp        = regexp.MustCompile(`[^a-z0-9-]`)
+	consecutiveHyphensRegexp = regexp.MustCompile(`-+`)
 )
 
 type loadbalancer struct {
@@ -54,10 +69,42 @@ func (lb *loadbalancer) GetLoadBalancer(ctx context.Context, clusterName string,
 	return status, true, nil
 }
 
-// GetLoadBalancerName is an implementation of LoadBalancer.GetLoadBalancerName.
+// GetLoadBalancerName returns the name to use for the infrastructure load balancer service.
+// When NamingStrategy is "semantic", it generates a predictable name from cluster, namespace,
+// and service name (can be overridden per-service with the kubevirt.io/set-loadbalancer-name
+// annotation). Otherwise it falls back to the legacy UID-based naming.
 func (lb *loadbalancer) GetLoadBalancerName(ctx context.Context, clusterName string, service *corev1.Service) string {
-	// TODO: replace DefaultLoadBalancerName to generate more meaningful loadbalancer names.
-	return cloudprovider.DefaultLoadBalancerName(service)
+	if lb.config.NamingStrategy != "semantic" {
+		return cloudprovider.DefaultLoadBalancerName(service)
+	}
+	if name, ok := service.Annotations[LoadBalancerNameAnnotation]; ok && name != "" {
+		if sanitized := sanitizeDNSName(name); sanitized != "" {
+			return sanitized
+		}
+	}
+	return generateLoadBalancerName(clusterName, service.Namespace, service.Name)
+}
+
+// generateLoadBalancerName creates a deterministic, human-readable name from
+// the cluster name, service namespace, and service name. If the result exceeds
+// 63 characters it is truncated with a hash suffix to preserve uniqueness.
+func generateLoadBalancerName(clusterName, serviceNamespace, serviceName string) string {
+	raw := clusterName + "-" + serviceNamespace + "-" + serviceName
+	name := sanitizeDNSName(raw)
+	if len(name) <= maxServiceNameLength {
+		return name
+	}
+	hash := fmt.Sprintf("%x", sha256.Sum256([]byte(raw)))[:8]
+	return name[:maxServiceNameLength-9] + "-" + hash
+}
+
+// sanitizeDNSName converts a string to a valid DNS label.
+func sanitizeDNSName(name string) string {
+	name = strings.ToLower(name)
+	name = nonDNSCharsRegexp.ReplaceAllString(name, "-")
+	name = consecutiveHyphensRegexp.ReplaceAllString(name, "-")
+	name = strings.Trim(name, "-")
+	return name
 }
 
 // EnsureLoadBalancer creates a new load balancer 'name', or updates the existing one. Returns the status of the balancer

--- a/pkg/provider/loadbalancer_test.go
+++ b/pkg/provider/loadbalancer_test.go
@@ -3,7 +3,6 @@ package provider
 import (
 	"context"
 	"errors"
-	"fmt"
 
 	mockclient "kubevirt.io/cloud-provider-kubevirt/pkg/provider/mock/client"
 
@@ -21,7 +20,7 @@ import (
 )
 
 const (
-	lbServiceName      string = "af6ebf1722bb111e9b210d663bd873d9"
+	lbServiceName      string = "kvcluster-service1"
 	lbServiceNamespace string = "test"
 	clusterName        string = "kvcluster"
 )
@@ -29,7 +28,7 @@ const (
 var (
 	svcEmptyStatus = corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "a6fa1a2662ad011e9b210d663bd873d9",
+			Name:      "ns1-svc1",
 			Namespace: "test",
 		},
 		Spec: corev1.ServiceSpec{
@@ -40,7 +39,7 @@ var (
 	}
 	svcHostnameIngress = corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "a6fa1a6582ad011e9b210d663bd873d9",
+			Name:      "cluster2-ns3-svc3",
 			Namespace: "test",
 		},
 		Status: corev1.ServiceStatus{
@@ -54,7 +53,7 @@ var (
 	}
 	svc4 = corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "a6fa1a50e2ad011e9b210d663bd873d9",
+			Name:      "cluster1-ns2-svc2",
 			Namespace: "test",
 		},
 		Spec: corev1.ServiceSpec{
@@ -170,17 +169,21 @@ var _ = Describe("LoadBalancer", func() {
 			lb = &loadbalancer{
 				namespace: "test",
 				client:    c,
+				config: LoadBalancerConfig{
+					NamingStrategy: "semantic",
+				},
 			}
+			notFoundSvc4 := apierrors.NewNotFound(schema.GroupResource{Group: "v1", Resource: "services"}, "cluster2-ns4-svc4")
 			gomock.InOrder(
-				c.EXPECT().Get(ctx, client.ObjectKey{Name: "a6fa1a2662ad011e9b210d663bd873d9", Namespace: "test"}, gomock.AssignableToTypeOf(&corev1.Service{})).SetArg(2, svcEmptyStatus),
-				c.EXPECT().Get(ctx, client.ObjectKey{Name: "a6fa1a50e2ad011e9b210d663bd873d9", Namespace: "test"}, gomock.AssignableToTypeOf(&corev1.Service{})).SetArg(2, svc4),
-				c.EXPECT().Get(ctx, client.ObjectKey{Name: "a6fa1a6582ad011e9b210d663bd873d9", Namespace: "test"}, gomock.AssignableToTypeOf(&corev1.Service{})).SetArg(2, svcHostnameIngress),
-				c.EXPECT().Get(ctx, client.ObjectKey{Name: "adoesnotexistink8s", Namespace: "test"}, gomock.AssignableToTypeOf(&corev1.Service{})).Return(apierrors.NewNotFound(schema.GroupResource{Group: "v1", Resource: "services"}, "adoesnotexistink8s")),
+				c.EXPECT().Get(ctx, client.ObjectKey{Name: "ns1-svc1", Namespace: "test"}, gomock.AssignableToTypeOf(&corev1.Service{})).SetArg(2, svcEmptyStatus),
+				c.EXPECT().Get(ctx, client.ObjectKey{Name: "cluster1-ns2-svc2", Namespace: "test"}, gomock.AssignableToTypeOf(&corev1.Service{})).SetArg(2, svc4),
+				c.EXPECT().Get(ctx, client.ObjectKey{Name: "cluster2-ns3-svc3", Namespace: "test"}, gomock.AssignableToTypeOf(&corev1.Service{})).SetArg(2, svcHostnameIngress),
+				c.EXPECT().Get(ctx, client.ObjectKey{Name: "cluster2-ns4-svc4", Namespace: "test"}, gomock.AssignableToTypeOf(&corev1.Service{})).Return(notFoundSvc4),
 			)
 		})
 
-		DescribeTable("Get loadbalancer", func(serviceUID types.UID, clusterName string, expectedLBStatus *corev1.LoadBalancerStatus, expectedExists bool, expectedError error) {
-			svc := &corev1.Service{ObjectMeta: metav1.ObjectMeta{UID: serviceUID}}
+		DescribeTable("Get loadbalancer", func(serviceName, serviceNamespace string, serviceUID types.UID, clusterName string, expectedLBStatus *corev1.LoadBalancerStatus, expectedExists bool, expectedError error) {
+			svc := &corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: serviceName, Namespace: serviceNamespace, UID: serviceUID}}
 			status, exists, err := lb.GetLoadBalancer(ctx, clusterName, svc)
 			Expect(cmpLoadBalancerStatuses(status, expectedLBStatus)).Should(BeTrue())
 			Expect(exists).Should(Equal(expectedExists))
@@ -191,10 +194,10 @@ var _ = Describe("LoadBalancer", func() {
 			}
 
 		},
-			Entry("Should return status with no IPs & hostnames", types.UID("6fa1a266-2ad0-11e9-b210-d663bd873d93"), "", makeLoadBalancerStatus([]string{}, []string{}), true, nil),
-			Entry("Should return status with IPs & no hostnames", types.UID("6fa1a50e-2ad0-11e9-b210-d663bd873d93"), "cluster1", makeLoadBalancerStatus([]string{"192.168.0.35"}, []string{}), true, nil),
-			Entry("Should return status with IPs & hostnames", types.UID("6fa1a658-2ad0-11e9-b210-d663bd873d93"), "cluster2", makeLoadBalancerStatus([]string{"192.168.0.36"}, []string{"lb1.example.com", "lb2.example.com"}), true, nil),
-			Entry("Should return with not-exist-status", types.UID("does-not-exist-in-k8s"), "cluster2", nil, false, nil),
+			Entry("Should return status with no IPs & hostnames", "svc1", "ns1", types.UID("6fa1a266-2ad0-11e9-b210-d663bd873d93"), "", makeLoadBalancerStatus([]string{}, []string{}), true, nil),
+			Entry("Should return status with IPs & no hostnames", "svc2", "ns2", types.UID("6fa1a50e-2ad0-11e9-b210-d663bd873d93"), "cluster1", makeLoadBalancerStatus([]string{"192.168.0.35"}, []string{}), true, nil),
+			Entry("Should return status with IPs & hostnames", "svc3", "ns3", types.UID("6fa1a658-2ad0-11e9-b210-d663bd873d93"), "cluster2", makeLoadBalancerStatus([]string{"192.168.0.36"}, []string{"lb1.example.com", "lb2.example.com"}), true, nil),
+			Entry("Should return with not-exist-status", "svc4", "ns4", types.UID("does-not-exist-in-k8s"), "cluster2", nil, false, nil),
 		)
 
 		AfterAll(func() {
@@ -217,18 +220,65 @@ var _ = Describe("LoadBalancer", func() {
 			lb = &loadbalancer{
 				namespace: "test",
 				client:    c,
+				config: LoadBalancerConfig{
+					NamingStrategy: "semantic",
+				},
 			}
 		})
 
-		DescribeTable("Get loadbalancer name", func(serviceUID types.UID, clusterName string, expectedName string) {
-			svc := &corev1.Service{ObjectMeta: metav1.ObjectMeta{UID: serviceUID}}
+		DescribeTable("Get loadbalancer name", func(serviceName, serviceNamespace string, clusterName string, expectedName string) {
+			svc := &corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: serviceName, Namespace: serviceNamespace}}
 			name := lb.GetLoadBalancerName(ctx, clusterName, svc)
 			Expect(name).Should(Equal(expectedName))
 		},
-			Entry(fmt.Sprintf("Should return loadbalancer with %s name ", "a6fa1a2662ad011e9b210d663bd873d9"), types.UID("6fa1a266-2ad0-11e9-b210-d663bd873d93"), "", "a6fa1a2662ad011e9b210d663bd873d9"),
-			Entry(fmt.Sprintf("Should return loadbalancer with %s name ", "a6fa1a50e2ad011e9b210d663bd873d9"), types.UID("6fa1a50e-2ad0-11e9-b210-d663bd873d93"), "cluster1", "a6fa1a50e2ad011e9b210d663bd873d9"),
-			Entry(fmt.Sprintf("Should return loadbalancer with %s name ", "a6fa1a6582ad011e9b210d663bd873d9"), types.UID("6fa1a658-2ad0-11e9-b210-d663bd873d93"), "cluster2", "a6fa1a6582ad011e9b210d663bd873d9"),
+			Entry("Should generate name from cluster and service", "nginx", "default", "mycluster", "mycluster-default-nginx"),
+			Entry("Should handle empty cluster name", "nginx", "default", "", "default-nginx"),
+			Entry("Should handle empty namespace", "nginx", "", "mycluster", "mycluster-nginx"),
+			Entry("Should sanitize special characters", "my_svc!", "ns-1", "cluster.1", "cluster-1-ns-1-my-svc"),
 		)
+
+		It("Should use annotation override when set", func() {
+			svc := &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "nginx",
+					Namespace: "default",
+					Annotations: map[string]string{
+						LoadBalancerNameAnnotation: "custom-lb-name",
+					},
+				},
+			}
+			name := lb.GetLoadBalancerName(ctx, "mycluster", svc)
+			Expect(name).Should(Equal("custom-lb-name"))
+		})
+
+		It("Should return legacy UID-based name when namingStrategy is not semantic", func() {
+			legacyLb := &loadbalancer{
+				namespace: "test",
+				client:    c,
+				config:    LoadBalancerConfig{},
+			}
+			svc := &corev1.Service{ObjectMeta: metav1.ObjectMeta{UID: types.UID("f6ebf172-2bb1-11e9-b210-d663bd873d93")}}
+			name := legacyLb.GetLoadBalancerName(ctx, "mycluster", svc)
+			Expect(name).Should(Equal("af6ebf1722bb111e9b210d663bd873d9"))
+		})
+
+		It("Should ignore annotation when namingStrategy is not semantic", func() {
+			legacyLb := &loadbalancer{
+				namespace: "test",
+				client:    c,
+				config:    LoadBalancerConfig{},
+			}
+			svc := &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					UID: types.UID("f6ebf172-2bb1-11e9-b210-d663bd873d93"),
+					Annotations: map[string]string{
+						LoadBalancerNameAnnotation: "custom-lb-name",
+					},
+				},
+			}
+			name := legacyLb.GetLoadBalancerName(ctx, "mycluster", svc)
+			Expect(name).Should(Equal("af6ebf1722bb111e9b210d663bd873d9"))
+		})
 
 		AfterAll(func() {
 			ctrl.Finish()
@@ -255,6 +305,7 @@ var _ = Describe("LoadBalancer", func() {
 				namespace: "test",
 				client:    c,
 				config: LoadBalancerConfig{
+					NamingStrategy:       "semantic",
 					CreationPollInterval: pointer.Int(1),
 					CreationPollTimeout:  pointer.Int(5),
 				},
@@ -290,7 +341,7 @@ var _ = Describe("LoadBalancer", func() {
 			lb.config.Selectorless = pointer.Bool(true)
 
 			c.EXPECT().
-				Get(ctx, client.ObjectKey{Name: "af6ebf1722bb111e9b210d663bd873d9", Namespace: "test"}, gomock.AssignableToTypeOf(&corev1.Service{})).
+				Get(ctx, client.ObjectKey{Name: "kvcluster-service1", Namespace: "test"}, gomock.AssignableToTypeOf(&corev1.Service{})).
 				Return(checkSvcExistErr)
 
 			infraService1 := generateInfraService(
@@ -318,7 +369,7 @@ var _ = Describe("LoadBalancer", func() {
 				}
 				c.EXPECT().Get(
 					ctx,
-					client.ObjectKey{Name: "af6ebf1722bb111e9b210d663bd873d9", Namespace: "test"},
+					client.ObjectKey{Name: "kvcluster-service1", Namespace: "test"},
 					gomock.AssignableToTypeOf(&corev1.Service{}),
 				).Do(func(ctx context.Context, key client.ObjectKey, obj client.Object, opts ...client.GetOption) {
 					infraService2.DeepCopyInto(obj.(*corev1.Service))
@@ -352,7 +403,7 @@ var _ = Describe("LoadBalancer", func() {
 			}
 
 			c.EXPECT().
-				Get(ctx, client.ObjectKey{Name: "af6ebf1722bb111e9b210d663bd873d9", Namespace: "test"}, gomock.AssignableToTypeOf(&corev1.Service{})).
+				Get(ctx, client.ObjectKey{Name: "kvcluster-service1", Namespace: "test"}, gomock.AssignableToTypeOf(&corev1.Service{})).
 				Return(checkSvcExistErr)
 
 			infraService1 := generateInfraService(
@@ -379,7 +430,7 @@ var _ = Describe("LoadBalancer", func() {
 				}
 				c.EXPECT().Get(
 					ctx,
-					client.ObjectKey{Name: "af6ebf1722bb111e9b210d663bd873d9", Namespace: "test"},
+					client.ObjectKey{Name: "kvcluster-service1", Namespace: "test"},
 					gomock.AssignableToTypeOf(&corev1.Service{}),
 				).Do(func(ctx context.Context, key client.ObjectKey, obj client.Object, opts ...client.GetOption) {
 					infraService2.DeepCopyInto(obj.(*corev1.Service))
@@ -414,7 +465,7 @@ var _ = Describe("LoadBalancer", func() {
 			}
 
 			c.EXPECT().
-				Get(ctx, client.ObjectKey{Name: "af6ebf1722bb111e9b210d663bd873d9", Namespace: "test"}, gomock.AssignableToTypeOf(&corev1.Service{})).
+				Get(ctx, client.ObjectKey{Name: "kvcluster-service1", Namespace: "test"}, gomock.AssignableToTypeOf(&corev1.Service{})).
 				Return(checkSvcExistErr)
 
 			infraService1 := generateInfraService(
@@ -441,7 +492,7 @@ var _ = Describe("LoadBalancer", func() {
 				}
 				c.EXPECT().Get(
 					ctx,
-					client.ObjectKey{Name: "af6ebf1722bb111e9b210d663bd873d9", Namespace: "test"},
+					client.ObjectKey{Name: "kvcluster-service1", Namespace: "test"},
 					gomock.AssignableToTypeOf(&corev1.Service{}),
 				).Do(func(ctx context.Context, key client.ObjectKey, obj client.Object, opts ...client.GetOption) {
 					infraService2.DeepCopyInto(obj.(*corev1.Service))
@@ -476,7 +527,7 @@ var _ = Describe("LoadBalancer", func() {
 			}
 
 			c.EXPECT().
-				Get(ctx, client.ObjectKey{Name: "af6ebf1722bb111e9b210d663bd873d9", Namespace: "test"}, gomock.AssignableToTypeOf(&corev1.Service{})).
+				Get(ctx, client.ObjectKey{Name: "kvcluster-service1", Namespace: "test"}, gomock.AssignableToTypeOf(&corev1.Service{})).
 				Return(checkSvcExistErr)
 
 			infraService1 := generateInfraService(
@@ -504,7 +555,7 @@ var _ = Describe("LoadBalancer", func() {
 				}
 				c.EXPECT().Get(
 					ctx,
-					client.ObjectKey{Name: "af6ebf1722bb111e9b210d663bd873d9", Namespace: "test"},
+					client.ObjectKey{Name: "kvcluster-service1", Namespace: "test"},
 					gomock.AssignableToTypeOf(&corev1.Service{}),
 				).Do(func(ctx context.Context, key client.ObjectKey, obj client.Object, opts ...client.GetOption) {
 					infraService2.DeepCopyInto(obj.(*corev1.Service))
@@ -537,7 +588,7 @@ var _ = Describe("LoadBalancer", func() {
 			}
 
 			c.EXPECT().
-				Get(ctx, client.ObjectKey{Name: "af6ebf1722bb111e9b210d663bd873d9", Namespace: "test"}, gomock.AssignableToTypeOf(&corev1.Service{})).
+				Get(ctx, client.ObjectKey{Name: "kvcluster-service1", Namespace: "test"}, gomock.AssignableToTypeOf(&corev1.Service{})).
 				Return(errors.New("Test error - check if service already exist"))
 
 			lbStatus, err := lb.EnsureLoadBalancer(ctx, clusterName, tenantService, nodes)
@@ -565,7 +616,7 @@ var _ = Describe("LoadBalancer", func() {
 
 			c.EXPECT().Get(
 				ctx,
-				client.ObjectKey{Name: "af6ebf1722bb111e9b210d663bd873d9", Namespace: "test"},
+				client.ObjectKey{Name: "kvcluster-service1", Namespace: "test"},
 				gomock.AssignableToTypeOf(&corev1.Service{}),
 			).Do(func(ctx context.Context, key client.ObjectKey, obj client.Object, opts ...client.GetOption) {
 				infraServiceExist.DeepCopyInto(obj.(*corev1.Service))
@@ -616,7 +667,7 @@ var _ = Describe("LoadBalancer", func() {
 
 			c.EXPECT().Get(
 				ctx,
-				client.ObjectKey{Name: "af6ebf1722bb111e9b210d663bd873d9", Namespace: "test"},
+				client.ObjectKey{Name: "kvcluster-service1", Namespace: "test"},
 				gomock.AssignableToTypeOf(&corev1.Service{}),
 			).Do(func(ctx context.Context, key client.ObjectKey, obj client.Object, opts ...client.GetOption) {
 				infraServiceExist.DeepCopyInto(obj.(*corev1.Service))
@@ -666,7 +717,7 @@ var _ = Describe("LoadBalancer", func() {
 
 			c.EXPECT().Get(
 				ctx,
-				client.ObjectKey{Name: "af6ebf1722bb111e9b210d663bd873d9", Namespace: "test"},
+				client.ObjectKey{Name: "kvcluster-service1", Namespace: "test"},
 				gomock.AssignableToTypeOf(&corev1.Service{}),
 			).Do(func(ctx context.Context, key client.ObjectKey, obj client.Object, opts ...client.GetOption) {
 				infraServiceExist.DeepCopyInto(obj.(*corev1.Service))
@@ -715,7 +766,7 @@ var _ = Describe("LoadBalancer", func() {
 			}
 
 			c.EXPECT().
-				Get(ctx, client.ObjectKey{Name: "af6ebf1722bb111e9b210d663bd873d9", Namespace: "test"}, gomock.AssignableToTypeOf(&corev1.Service{})).
+				Get(ctx, client.ObjectKey{Name: "kvcluster-service1", Namespace: "test"}, gomock.AssignableToTypeOf(&corev1.Service{})).
 				Return(notFoundErr)
 
 			infraService1 := generateInfraService(
@@ -752,7 +803,7 @@ var _ = Describe("LoadBalancer", func() {
 			}
 
 			c.EXPECT().
-				Get(ctx, client.ObjectKey{Name: "af6ebf1722bb111e9b210d663bd873d9", Namespace: "test"}, gomock.AssignableToTypeOf(&corev1.Service{})).
+				Get(ctx, client.ObjectKey{Name: "kvcluster-service1", Namespace: "test"}, gomock.AssignableToTypeOf(&corev1.Service{})).
 				Return(notFoundErr)
 
 			infraService1 := generateInfraService(
@@ -779,7 +830,7 @@ var _ = Describe("LoadBalancer", func() {
 				}
 				c.EXPECT().Get(
 					ctx,
-					client.ObjectKey{Name: "af6ebf1722bb111e9b210d663bd873d9", Namespace: "test"},
+					client.ObjectKey{Name: "kvcluster-service1", Namespace: "test"},
 					gomock.AssignableToTypeOf(&corev1.Service{}),
 				).Do(func(ctx context.Context, key client.ObjectKey, obj client.Object, opts ...client.GetOption) {
 					infraService2.DeepCopyInto(obj.(*corev1.Service))
@@ -811,7 +862,7 @@ var _ = Describe("LoadBalancer", func() {
 			}
 
 			c.EXPECT().
-				Get(ctx, client.ObjectKey{Name: "af6ebf1722bb111e9b210d663bd873d9", Namespace: "test"}, gomock.AssignableToTypeOf(&corev1.Service{})).
+				Get(ctx, client.ObjectKey{Name: "kvcluster-service1", Namespace: "test"}, gomock.AssignableToTypeOf(&corev1.Service{})).
 				Return(notFoundErr)
 
 			infraService1 := generateInfraService(
@@ -828,7 +879,7 @@ var _ = Describe("LoadBalancer", func() {
 				if i == getCount-1 {
 					c.EXPECT().Get(
 						ctx,
-						client.ObjectKey{Name: "af6ebf1722bb111e9b210d663bd873d9", Namespace: "test"},
+						client.ObjectKey{Name: "kvcluster-service1", Namespace: "test"},
 						gomock.AssignableToTypeOf(&corev1.Service{}),
 					).Do(func(ctx context.Context, key client.ObjectKey, obj client.Object, opts ...client.GetOption) {
 						infraService2.DeepCopyInto(obj.(*corev1.Service))
@@ -836,7 +887,7 @@ var _ = Describe("LoadBalancer", func() {
 				} else {
 					c.EXPECT().Get(
 						ctx,
-						client.ObjectKey{Name: "af6ebf1722bb111e9b210d663bd873d9", Namespace: "test"},
+						client.ObjectKey{Name: "kvcluster-service1", Namespace: "test"},
 						gomock.AssignableToTypeOf(&corev1.Service{}),
 					).Do(func(ctx context.Context, key client.ObjectKey, obj client.Object, opts ...client.GetOption) {
 						infraService2.DeepCopyInto(obj.(*corev1.Service))
@@ -856,7 +907,7 @@ var _ = Describe("LoadBalancer", func() {
 			expectedError := errors.New("timed out waiting for the condition")
 
 			c.EXPECT().
-				Get(ctx, client.ObjectKey{Name: "af6ebf1722bb111e9b210d663bd873d9", Namespace: "test"}, gomock.AssignableToTypeOf(&corev1.Service{})).
+				Get(ctx, client.ObjectKey{Name: "kvcluster-service1", Namespace: "test"}, gomock.AssignableToTypeOf(&corev1.Service{})).
 				Return(notFoundErr)
 
 			infraService1 := generateInfraService(
@@ -871,7 +922,7 @@ var _ = Describe("LoadBalancer", func() {
 			infraService2 := infraService1.DeepCopy()
 			c.EXPECT().Get(
 				ctx,
-				client.ObjectKey{Name: "af6ebf1722bb111e9b210d663bd873d9", Namespace: "test"},
+				client.ObjectKey{Name: "kvcluster-service1", Namespace: "test"},
 				gomock.AssignableToTypeOf(&corev1.Service{}),
 			).Do(func(ctx context.Context, key client.ObjectKey, obj client.Object, opts ...client.GetOption) {
 				infraService2.DeepCopyInto(obj.(*corev1.Service))
@@ -907,6 +958,7 @@ var _ = Describe("LoadBalancer", func() {
 				namespace: "test",
 				client:    c,
 				config: LoadBalancerConfig{
+					NamingStrategy:       "semantic",
 					CreationPollInterval: pointer.Int(1),
 				},
 			}
@@ -953,7 +1005,7 @@ var _ = Describe("LoadBalancer", func() {
 
 			c.EXPECT().Get(
 				ctx,
-				client.ObjectKey{Name: "af6ebf1722bb111e9b210d663bd873d9", Namespace: "test"},
+				client.ObjectKey{Name: "kvcluster-service1", Namespace: "test"},
 				gomock.AssignableToTypeOf(&corev1.Service{}),
 			).Do(func(ctx context.Context, key client.ObjectKey, obj client.Object, opts ...client.GetOption) {
 				infraServiceExist.DeepCopyInto(obj.(*corev1.Service))
@@ -1004,7 +1056,7 @@ var _ = Describe("LoadBalancer", func() {
 
 			c.EXPECT().Get(
 				ctx,
-				client.ObjectKey{Name: "af6ebf1722bb111e9b210d663bd873d9", Namespace: "test"},
+				client.ObjectKey{Name: "kvcluster-service1", Namespace: "test"},
 				gomock.AssignableToTypeOf(&corev1.Service{}),
 			).Do(func(ctx context.Context, key client.ObjectKey, obj client.Object, opts ...client.GetOption) {
 				infraServiceExist.DeepCopyInto(obj.(*corev1.Service))
@@ -1052,7 +1104,7 @@ var _ = Describe("LoadBalancer", func() {
 
 			c.EXPECT().Get(
 				ctx,
-				client.ObjectKey{Name: "af6ebf1722bb111e9b210d663bd873d9", Namespace: "test"},
+				client.ObjectKey{Name: "kvcluster-service1", Namespace: "test"},
 				gomock.AssignableToTypeOf(&corev1.Service{}),
 			).Return(errors.New("Test error - Get Service"))
 
@@ -1061,7 +1113,6 @@ var _ = Describe("LoadBalancer", func() {
 		})
 
 		It("Should return an error if service not found", func() {
-			expectedError := notFoundErr
 			changedPort := 30002
 			infraServiceExist := generateInfraService(
 				tenantService,
@@ -1081,12 +1132,12 @@ var _ = Describe("LoadBalancer", func() {
 
 			c.EXPECT().Get(
 				ctx,
-				client.ObjectKey{Name: "af6ebf1722bb111e9b210d663bd873d9", Namespace: "test"},
+				client.ObjectKey{Name: "kvcluster-service1", Namespace: "test"},
 				gomock.AssignableToTypeOf(&corev1.Service{}),
 			).Return(notFoundErr)
 
 			err := lb.UpdateLoadBalancer(ctx, clusterName, tenantService, nodes)
-			Expect(err).Should(Equal(expectedError))
+			Expect(err).Should(Equal(notFoundErr))
 		})
 
 		It("Should return an error if update fails with ports changed", func() {
@@ -1109,7 +1160,7 @@ var _ = Describe("LoadBalancer", func() {
 			}
 			c.EXPECT().Get(
 				ctx,
-				client.ObjectKey{Name: "af6ebf1722bb111e9b210d663bd873d9", Namespace: "test"},
+				client.ObjectKey{Name: "kvcluster-service1", Namespace: "test"},
 				gomock.AssignableToTypeOf(&corev1.Service{}),
 			).Do(func(ctx context.Context, key client.ObjectKey, obj client.Object, opts ...client.GetOption) {
 				infraServiceExist.DeepCopyInto(obj.(*corev1.Service))
@@ -1161,6 +1212,7 @@ var _ = Describe("LoadBalancer", func() {
 				namespace: "test",
 				client:    c,
 				config: LoadBalancerConfig{
+					NamingStrategy:       "semantic",
 					CreationPollInterval: pointer.Int(1),
 				},
 			}
@@ -1203,7 +1255,7 @@ var _ = Describe("LoadBalancer", func() {
 			}
 			c.EXPECT().Get(
 				ctx,
-				client.ObjectKey{Name: "af6ebf1722bb111e9b210d663bd873d9", Namespace: "test"},
+				client.ObjectKey{Name: "kvcluster-service1", Namespace: "test"},
 				gomock.AssignableToTypeOf(&corev1.Service{}),
 			).Do(func(ctx context.Context, key client.ObjectKey, obj client.Object, opts ...client.GetOption) {
 				if getSvcErr == nil {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Replaces the deprecated `cloudprovider.DefaultLoadBalancerName` (which generates opaque UID-based names like `af6ebf1722bb111e9b210d663bd873d9`) with an opt-in semantic naming strategy that produces predictable, human-readable infrastructure load balancer service names.

When `namingStrategy: semantic` is set in the cloud config, LB services are named `<clusterName>-<namespace>-<serviceName>` (e.g. mycluster-default-nginx). Names are DNS-sanitized and truncated with a hash suffix if they exceed 63 characters. Individual services can override the generated name via the `kubevirt.io/set-loadbalancer-name` annotation.

The default behavior is unchanged — existing deployments continue using the legacy UID-based naming unless the flag is explicitly set.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
